### PR TITLE
Normalise the AWS policy document

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9d162745937d6acc14fd4e0856e032712eda907d228800e675c0e78d261870a8
-updated: 2016-08-04T14:46:55.547185276+10:00
+hash: a16497b7740f1b8224f4c590d200975cafd9b2b2a287bee941ce4329cd995947
+updated: 2016-09-01T11:52:37.703686061+10:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -8,45 +8,48 @@ imports:
 - name: github.com/alecthomas/units
   version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - name: github.com/aws/aws-sdk-go
-  version: 83c400dd354759bdb2fb49f9c6e53cee3e0c9484
+  version: d6b4bfeba6997082629986cac2a932a233ba745e
   subpackages:
   - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/request
   - aws/session
+  - aws/signer/v4
+  - private/endpoints
+  - private/protocol
+  - private/protocol/ec2query
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
+  - private/waiter
   - service/ec2
   - service/iam
   - service/iam/iamiface
-  - aws/awserr
   - service/s3
   - service/s3/s3iface
-  - aws/credentials
-  - aws/client
-  - aws/corehandlers
-  - aws/defaults
-  - aws/request
-  - private/endpoints
-  - aws/awsutil
-  - aws/client/metadata
-  - private/protocol
-  - private/protocol/ec2query
-  - private/signer/v4
-  - private/waiter
-  - private/protocol/query
-  - private/protocol/restxml
-  - aws/credentials/ec2rolecreds
-  - aws/ec2metadata
-  - private/protocol/query/queryutil
-  - private/protocol/xml/xmlutil
-  - private/protocol/rest
+  - service/sts
+- name: github.com/cloudfoundry-incubator/candiedyaml
+  version: 99c3df83b51532e3615f851d8c2dbb638f5313bf
+- name: github.com/ghodss/yaml
+  version: aa0c862057666179de291b67d9f093d12b5a8473
 - name: github.com/go-ini/ini
-  version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
 - name: github.com/jmespath/go-jmespath
-  version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
-- name: github.com/mtibben/yamljsonmap
-  version: 61ad1237ec8b3d5057d5cccfdc8ab2e3341ab4be
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/pkg/errors
-  version: 2a9be18ecd8c148be18be08a811e33809206da19
+  version: 17b591df37844cde689f4d5813e5cea0927d8dd2
 - name: gopkg.in/alecthomas/kingpin.v2
-  version: 8cccfa8eb2e3183254457fb1749b2667fbc364c7
-- name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
-devImports: []
+  version: e9044be3ab2a8e11d4e1f418d12f0790d57e8d70
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,13 +1,18 @@
 package: github.com/99designs/iamy
 import:
 - package: github.com/aws/aws-sdk-go
+  version: ~1.4.5
   subpackages:
   - aws
+  - aws/awserr
   - aws/session
   - service/ec2
   - service/iam
   - service/iam/iamiface
-- package: github.com/mtibben/yamljsonmap
-- package: gopkg.in/alecthomas/kingpin.v2
-- package: gopkg.in/yaml.v2
+  - service/s3
+  - service/s3/s3iface
+- package: github.com/ghodss/yaml
 - package: github.com/pkg/errors
+  version: ~0.7.1
+- package: gopkg.in/alecthomas/kingpin.v2
+  version: ~2.2.3

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -62,7 +62,7 @@ func (a *AwsFetcher) Fetch() (*AccountData, error) {
 	wg.Wait()
 
 	if iamErr != nil {
-		return nil, errors.Wrap(iamErr, "Error fetching IAM error")
+		return nil, errors.Wrap(iamErr, "Error fetching IAM data")
 	}
 	if s3Err != nil {
 		return nil, errors.Wrap(s3Err, "Error fetching S3 data")

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -1,63 +1,10 @@
 package iamy
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/url"
 	"regexp"
 	"strings"
-
-	"github.com/mtibben/yamljsonmap"
 )
-
-type PolicyDocument yamljsonmap.StringKeyMap
-
-func (p *PolicyDocument) Encode() string {
-	return url.QueryEscape(string(p.json()))
-}
-
-func (p PolicyDocument) json() []byte {
-	jsonBytes, err := json.Marshal(yamljsonmap.StringKeyMap(p))
-	if err != nil {
-		panic(err.Error())
-	}
-	return jsonBytes
-}
-
-func (p *PolicyDocument) JsonString() string {
-	var out bytes.Buffer
-	json.Indent(&out, p.json(), "", "  ")
-	return out.String()
-}
-
-func (m PolicyDocument) MarshalJSON() ([]byte, error) {
-	return json.Marshal(yamljsonmap.StringKeyMap(m))
-}
-
-func (m *PolicyDocument) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var n yamljsonmap.StringKeyMap
-	if err := unmarshal(&n); err != nil {
-		return err
-	}
-	*m = PolicyDocument(n)
-
-	return nil
-}
-
-func NewPolicyDocumentFromEncodedJson(encoded string) (PolicyDocument, error) {
-	jsonString, err := url.QueryUnescape(encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	var doc PolicyDocument
-	if err = json.Unmarshal([]byte(jsonString), &doc); err != nil {
-		return nil, err
-	}
-
-	return doc, nil
-}
 
 type Account struct {
 	Id    string
@@ -103,8 +50,8 @@ func Arn(r AwsResource, a *Account) string {
 }
 
 type iamService struct {
-	Name string `yaml:"-"`
-	Path string `yaml:"-"`
+	Name string `json:"-"`
+	Path string `json:"-"`
 }
 
 func (s iamService) Service() string {
@@ -120,10 +67,10 @@ func (s iamService) ResourcePath() string {
 }
 
 type User struct {
-	iamService     `yaml:"-"`
-	Groups         []string       `yaml:"Groups,omitempty"`
-	InlinePolicies []InlinePolicy `yaml:"InlinePolicies,omitempty"`
-	Policies       []string       `yaml:"Policies,omitempty"`
+	iamService     `json:"-"`
+	Groups         []string       `json:"Groups,omitempty"`
+	InlinePolicies []InlinePolicy `json:"InlinePolicies,omitempty"`
+	Policies       []string       `json:"Policies,omitempty"`
 }
 
 func (u User) ResourceType() string {
@@ -131,9 +78,9 @@ func (u User) ResourceType() string {
 }
 
 type Group struct {
-	iamService     `yaml:"-"`
-	InlinePolicies []InlinePolicy `yaml:"InlinePolicies,omitempty"`
-	Policies       []string       `yaml:"Policies,omitempty"`
+	iamService     `json:"-"`
+	InlinePolicies []InlinePolicy `json:"InlinePolicies,omitempty"`
+	Policies       []string       `json:"Policies,omitempty"`
 }
 
 func (g Group) ResourceType() string {
@@ -141,13 +88,13 @@ func (g Group) ResourceType() string {
 }
 
 type InlinePolicy struct {
-	Name   string         `yaml:"Name"`
-	Policy PolicyDocument `yaml:"Policy"`
+	Name   string          `json:"Name"`
+	Policy *PolicyDocument `json:"Policy"`
 }
 
 type Policy struct {
-	iamService `yaml:"-"`
-	Policy     PolicyDocument `yaml:"Policy"`
+	iamService `json:"-"`
+	Policy     *PolicyDocument `json:"Policy"`
 }
 
 func (p Policy) ResourceType() string {
@@ -155,10 +102,10 @@ func (p Policy) ResourceType() string {
 }
 
 type Role struct {
-	iamService               `yaml:"-"`
-	AssumeRolePolicyDocument PolicyDocument `yaml:"AssumeRolePolicyDocument"`
-	InlinePolicies           []InlinePolicy `yaml:"InlinePolicies,omitempty"`
-	Policies                 []string       `yaml:"Policies,omitempty"`
+	iamService               `json:"-"`
+	AssumeRolePolicyDocument *PolicyDocument `json:"AssumeRolePolicyDocument"`
+	InlinePolicies           []InlinePolicy  `json:"InlinePolicies,omitempty"`
+	Policies                 []string        `json:"Policies,omitempty"`
 }
 
 func (r Role) ResourceType() string {
@@ -166,8 +113,8 @@ func (r Role) ResourceType() string {
 }
 
 type BucketPolicy struct {
-	BucketName string         `yaml:"-"`
-	Policy     PolicyDocument `yaml:"Policy"`
+	BucketName string          `json:"-"`
+	Policy     *PolicyDocument `json:"Policy"`
 }
 
 func (u BucketPolicy) Service() string {

--- a/iamy/models_test.go
+++ b/iamy/models_test.go
@@ -1,23 +1,6 @@
 package iamy
 
-import (
-	"fmt"
-	"testing"
-)
-
-func TestPolicyDocumentEncodingRoundTrip(t *testing.T) {
-	policy := PolicyDocument{
-		"foo": map[string]string{
-			"bar": "baz",
-		},
-	}
-	encodedPolicy := policy.Encode()
-	result, _ := NewPolicyDocumentFromEncodedJson(encodedPolicy)
-
-	if fmt.Sprintf("%v", result) != fmt.Sprintf("%v", policy) {
-		t.Errorf("PolicyDocument failed an Encode roundtrip, got %#v, expected %#v", result, policy)
-	}
-}
+import "testing"
 
 func TestNewAccountFromString(t *testing.T) {
 

--- a/iamy/policy.go
+++ b/iamy/policy.go
@@ -1,0 +1,118 @@
+package iamy
+
+import (
+	"encoding/json"
+	"log"
+	"net/url"
+	"reflect"
+	"sort"
+)
+
+func NewPolicyDocumentFromEncodedJson(encoded string) (*PolicyDocument, error) {
+	jsonString, err := url.QueryUnescape(encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	var doc PolicyDocument
+	if err = json.Unmarshal([]byte(jsonString), &doc); err != nil {
+		return nil, err
+	}
+
+	return &doc, nil
+}
+
+// PolicyDocument represents an AWS policy document.
+// It normalises the data when Marshaling and Unmarshaling JSON
+// the same way AWS does to avoid conflicts when diffing
+type PolicyDocument struct {
+	data interface{}
+}
+
+func (p *PolicyDocument) JsonString() string {
+	jsonBytes, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return string(jsonBytes)
+}
+
+func (p PolicyDocument) MarshalJSON() ([]byte, error) {
+	return json.Marshal(recursivelyNormaliseAwsPolicy(p.data))
+}
+
+func (p *PolicyDocument) UnmarshalJSON(jsonData []byte) error {
+	err := json.Unmarshal(jsonData, &p.data)
+	p.data = recursivelyNormaliseAwsPolicy(p.data)
+	return err
+}
+
+// RecursivelyNormaliseAwsPolicy recursively searches i for slices
+// and normalises
+//  1. slices of length 1 become single strings
+//  2. slices of length > 1 are sorted
+func recursivelyNormaliseAwsPolicy(i interface{}) interface{} {
+
+	switch reflect.TypeOf(i).Kind() {
+
+	case reflect.Map:
+		origMap := reflect.ValueOf(i)
+		newMap := reflect.MakeMap(origMap.Type())
+		for _, key := range origMap.MapKeys() {
+			originalValue := origMap.MapIndex(key).Interface()
+			newValue := recursivelyNormaliseAwsPolicy(originalValue)
+			newMap.SetMapIndex(key, reflect.ValueOf(newValue))
+		}
+		return newMap.Interface()
+
+	case reflect.Slice:
+		if ss, ok := i.([]string); ok {
+			if len(ss) == 1 {
+				return ss[0]
+			}
+			sort.Strings(ss)
+			return ss
+		}
+
+		if ii, ok := i.([]interface{}); ok {
+			if len(ii) > 0 {
+				// if it's actually a string slice
+				if _, ok := ii[0].(string); ok {
+					if len(ii) == 1 {
+						return ii[0]
+					}
+					ss := interfaceSliceToStringSlice(ii)
+					sort.Strings(ss)
+					return stringSliceToInterfaceSlice(ss)
+				} else {
+					origSlice := reflect.ValueOf(ii)
+					newSlice := reflect.MakeSlice(origSlice.Type(), 0, origSlice.Cap())
+					for _, originalValue := range ii {
+						newValue := recursivelyNormaliseAwsPolicy(originalValue)
+						newSlice = reflect.Append(newSlice, reflect.ValueOf(newValue))
+					}
+					return newSlice.Interface()
+				}
+			}
+		}
+	}
+
+	return i
+}
+
+func interfaceSliceToStringSlice(a []interface{}) []string {
+	b := make([]string, len(a))
+	for i := range a {
+		b[i] = a[i].(string)
+	}
+	return b
+}
+
+func stringSliceToInterfaceSlice(a []string) []interface{} {
+	b := make([]interface{}, len(a))
+	for i := range a {
+		b[i] = a[i]
+	}
+	return b
+}

--- a/iamy/policy_test.go
+++ b/iamy/policy_test.go
@@ -1,0 +1,128 @@
+package iamy
+
+import (
+	"reflect"
+	"testing"
+)
+
+type normaliseTest struct {
+	description string
+	input       interface{}
+	expected    interface{}
+}
+
+var normaliseTests = []normaliseTest{
+	{
+		"data not requiring normalisation should not change",
+		map[string]interface{}{
+			"a": "1",
+			"b": map[string]string{
+				"aa": "11",
+				"bb": "22",
+			},
+			"c": []string{
+				"11",
+				"22",
+			},
+		},
+		map[string]interface{}{
+			"a": "1",
+			"b": map[string]string{
+				"aa": "11",
+				"bb": "22",
+			},
+			"c": []string{
+				"11",
+				"22",
+			},
+		},
+	},
+
+	{
+		"slice with length of one should be normalised",
+		map[string]interface{}{
+			"a": []string{
+				"11",
+			},
+		},
+		map[string]interface{}{
+			"a": "11",
+		},
+	},
+
+	{
+		"string slice should get sorted",
+		map[string]interface{}{
+			"sort-test": []string{
+				"r",
+				"t",
+				"a",
+				"d",
+			},
+		},
+		map[string]interface{}{
+			"sort-test": []string{
+				"a",
+				"d",
+				"r",
+				"t",
+			},
+		},
+	},
+
+	{
+		"interface slice should get sorted",
+		map[string]interface{}{
+			"sort-test": []interface{}{
+				"r",
+				"t",
+				"a",
+				"d",
+			},
+		},
+		map[string]interface{}{
+			"sort-test": []interface{}{
+				"a",
+				"d",
+				"r",
+				"t",
+			},
+		},
+	},
+
+	{
+		"nested interface slice should get sorted",
+		[]interface{}{
+			map[string]interface{}{
+				"sort-test": []interface{}{
+					"r",
+					"t",
+					"a",
+					"d",
+				},
+			},
+		},
+		[]interface{}{
+			map[string]interface{}{
+				"sort-test": []interface{}{
+					"a",
+					"d",
+					"r",
+					"t",
+				},
+			},
+		},
+	},
+}
+
+func TestRecursivelyNormaliseAwsPolicy(t *testing.T) {
+	for _, nt := range normaliseTests {
+		result := recursivelyNormaliseAwsPolicy(nt.input)
+		if !reflect.DeepEqual(result, nt.expected) {
+			t.Errorf(`%s.
+Input:   %#v
+Expected %#v
+Actual:  %#v`, nt.description, nt.input, nt.expected, result)
+		}
+	}
+}

--- a/iamy/testdata/myalias-123/s3/my-bucket.yaml
+++ b/iamy/testdata/myalias-123/s3/my-bucket.yaml
@@ -4,5 +4,15 @@ Policy:
     Effect: Allow
     Principal: '*'
     Resource: arn:aws:s3:::my-bucket/*
-    Sid: AddPerm
+    Sid: AllowGet
+  - Action:
+    - s3:ListBucket
+    - s3:GetBucketLocation
+    Effect: Allow
+    Principal:
+      AWS:
+      - arn:aws:iam::111111111111:root
+      - arn:aws:iam::222222222222:root
+    Resource: arn:aws:s3:::my-bucket-2
+    Sid: AllowList
   Version: 2012-10-17

--- a/iamy/yaml.go
+++ b/iamy/yaml.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"text/template"
 
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 )
 
 const pathTemplateBlob = "{{.Account}}/{{.Resource.Service}}/{{.Resource.ResourceType}}{{.Resource.ResourcePath}}{{.Resource.ResourceName}}.yaml"


### PR DESCRIPTION
Normalises the AWS policy document when Marshaling and Unmarshaling to avoid conflicts when diffing. Fixes #13 

I've switched yaml implementation to github.com/ghodss/yaml which uses candiedyaml - not ideal, but unfortunately gopkg.in/yaml.v2 unmashals to `map[interface{}]interface{}` which json.Marshal can't handle. This is the same issue I created https://github.com/mtibben/yamljsonmap to address

However this seems to do the trick for now