### PR TITLE
Colour destructive commands red

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0cb23061cb60a09af4d90ba64ea5b3e14b349deeb1a083971b35b2881bf3edd6
-updated: 2017-03-22T10:45:42.014436092+11:00
+hash: c8d9a1459e2ffd6d79dfc78a736d959d8138d144113d8983d93841c81fb81de1
+updated: 2017-03-27T14:43:44.070292998+11:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -8,7 +8,7 @@ imports:
 - name: github.com/alecthomas/units
   version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - name: github.com/aws/aws-sdk-go
-  version: 695fe24acaf9afe80b0ce261d4637f42ba0b4c7d
+  version: d122c9c0e1d875585918c85cf6eba7e5e43f221d
   subpackages:
   - aws
   - aws/awserr
@@ -33,7 +33,6 @@ imports:
   - private/protocol/rest
   - private/protocol/restxml
   - private/protocol/xml/xmlutil
-  - private/waiter
   - service/ec2
   - service/iam
   - service/iam/iamiface
@@ -42,14 +41,27 @@ imports:
   - service/sts
 - name: github.com/cloudfoundry-incubator/candiedyaml
   version: 99c3df83b51532e3615f851d8c2dbb638f5313bf
+- name: github.com/fatih/color
+  version: 9131ab34cf20d2f6d83fdc67168a5430d1c7dc23
 - name: github.com/ghodss/yaml
   version: aa0c862057666179de291b67d9f093d12b5a8473
 - name: github.com/go-ini/ini
   version: 6e4869b434bd001f6983749881c7ead3545887d8
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/mattn/go-colorable
+  version: 5411d3eea5978e6cdc258b30de592b60df6aba96
+  repo: https://github.com/mattn/go-colorable
+- name: github.com/mattn/go-isatty
+  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+  repo: https://github.com/mattn/go-isatty
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
+- name: golang.org/x/sys
+  version: e24f485414aeafb646f6fca458b0bf869c0880a1
+  repo: https://go.googlesource.com/sys
+  subpackages:
+  - unix
 - name: gopkg.in/alecthomas/kingpin.v2
   version: e9044be3ab2a8e11d4e1f418d12f0790d57e8d70
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,3 +16,5 @@ import:
   version: ^0.7.1
 - package: gopkg.in/alecthomas/kingpin.v2
   version: ^2.2.3
+- package: github.com/fatih/color
+  version: ^1.4.1

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -26,6 +26,17 @@ func (c Cmd) String() string {
 	return strings.Join(parts, " ")
 }
 
+// IsDestructive indicates if the aws command is destructive
+func (c Cmd) IsDestructive() bool {
+	if len(c.Args) >= 2 {
+		a := c.Args[1]
+		if strings.HasPrefix(a, "de") || strings.HasPrefix(a, "remove") {
+			return true
+		}
+	}
+	return false
+}
+
 type CmdList []Cmd
 
 func (cc *CmdList) Add(name string, args ...string) {

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -52,6 +52,20 @@ func (cc CmdList) String() string {
 	return strings.Join(parts, "\n")
 }
 
+func (cc CmdList) Count() int {
+	return len(cc)
+}
+
+func (cc CmdList) CountDestructive() int {
+	count := 0
+	for _, c := range cc {
+		if c.IsDestructive() {
+			count++
+		}
+	}
+	return count
+}
+
 func path(v string) string {
 	if v == "" {
 		return "/"

--- a/push.go
+++ b/push.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/99designs/iamy/iamy"
+	"github.com/fatih/color"
 )
 
 type PushCommandInput struct {
@@ -42,6 +43,16 @@ func PushCommand(ui Ui, input PushCommandInput) {
 	ui.Println("No files found for AWS Account ID " + dataFromAws.Account.Id)
 }
 
+func printCommands(prefix string, awsCmds iamy.CmdList, ui Ui) {
+	for _, cmd := range awsCmds {
+		cmdStr := cmd.String()
+		if cmd.IsDestructive() {
+			cmdStr = color.RedString(cmdStr)
+		}
+		ui.Println(prefix + cmdStr)
+	}
+}
+
 func sync(yamlData iamy.AccountData, awsData *iamy.AccountData, ui Ui) {
 	ui.Debug.Printf("Generating sync commands for %s", awsData.Account.String())
 
@@ -52,8 +63,8 @@ func sync(yamlData iamy.AccountData, awsData *iamy.AccountData, ui Ui) {
 	}
 
 	ui.Println("Commands to push changes to AWS:\n")
-	prefix := "        "
-	ui.Println(prefix + strings.Replace(awsCmds.String(), "\n", "\n"+prefix, -1))
+
+	printCommands("      ", awsCmds, ui)
 
 	r, err := prompt(fmt.Sprintf("\nRun all aws commands? (y/N) "))
 	if err != nil {

--- a/push.go
+++ b/push.go
@@ -66,7 +66,7 @@ func sync(yamlData iamy.AccountData, awsData *iamy.AccountData, ui Ui) {
 
 	printCommands("      ", awsCmds, ui)
 
-	r, err := prompt(fmt.Sprintf("\nRun all aws commands? (y/N) "))
+	r, err := prompt(fmt.Sprintf("\nRun %d aws commands (%d destructive)? (y/N) ", awsCmds.Count(), awsCmds.CountDestructive()))
 	if err != nil {
 		ui.Fatal(err)
 		return


### PR DESCRIPTION
To ensure that destructive commands are visible, any aws command that starts with `detach`, `delete`, `deactivate` or `remove` are coloured red.

Also updates the prompt with a more info about destructive commands
```
Run 5 aws commands (3 destructive)? (y/N)
```

Fixes #24
