### PR TITLE
Support for Policy description

### DIFF
--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -214,22 +214,23 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 		}
 
 		for _, version := range policyResp.PolicyVersionList {
-			if *version.IsDefaultVersion {
-				doc, err := NewPolicyDocumentFromEncodedJson(*version.Document)
-				if err != nil {
-					return err
-				}
-
-				p := Policy{
-					iamService: iamService{
-						Name: *policyResp.PolicyName,
-						Path: *policyResp.Path,
-					},
-					Policy: doc,
-				}
-
-				a.data.Policies = append(a.data.Policies, p)
+			if !*version.IsDefaultVersion {
+				continue
 			}
+			doc, err := NewPolicyDocumentFromEncodedJson(*version.Document)
+			if err != nil {
+				return err
+			}
+
+			p := Policy{
+				iamService: iamService{
+					Name: *policyResp.PolicyName,
+					Path: *policyResp.Path,
+				},
+				Policy: doc,
+			}
+
+			a.data.Policies = append(a.data.Policies, p)
 		}
 	}
 

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -10,18 +10,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-type Mode int
-
-const (
-	ModePush Mode = iota
-	ModePull
-)
-
 var cfnResourceRegexp = regexp.MustCompile(`-[A-Z0-9]{10,20}$`)
 
-// An AwsFetcher fetches account data from AWS
+// AwsFetcher fetches account data from AWS
 type AwsFetcher struct {
-	Mode Mode
+	// As Policy descriptions are immutable, you can skip updating them
+	// when pushing to AWS
+	SkipFetchingPolicyDescriptions bool
 
 	iam     *iamClient
 	s3      *s3Client
@@ -144,7 +139,36 @@ func (a *AwsFetcher) populateInlinePolicies(source []*iam.PolicyDetail, target *
 	return nil
 }
 
+func (a *AwsFetcher) fetchPolicyDescriptions(resp *iam.GetAccountAuthorizationDetailsOutput) error {
+	log.Println("Fetching Policy descriptions")
+	var err error
+	var wg sync.WaitGroup
+	for _, policyResp := range resp.Policies {
+		if cfnResourceRegexp.MatchString(*policyResp.PolicyName) {
+			continue
+		}
+
+		wg.Add(1)
+		go func(policy *iam.ManagedPolicyDetail) {
+			defer wg.Done()
+			desc, fetchErr := a.iam.getPolicyDescription(*policy.Arn)
+			policy.SetDescription(desc)
+			if fetchErr != nil {
+				err = fetchErr
+			}
+		}(policyResp)
+
+	}
+	wg.Wait()
+
+	return err
+}
+
 func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOutput) error {
+	if !a.SkipFetchingPolicyDescriptions {
+		a.fetchPolicyDescriptions(resp)
+	}
+
 	for _, userResp := range resp.UserDetailList {
 		if cfnResourceRegexp.MatchString(*userResp.UserName) {
 			log.Printf("Skipping CloudFormation generated user %s", *userResp.UserName)
@@ -222,39 +246,34 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 			continue
 		}
 
-		for _, version := range policyResp.PolicyVersionList {
-			if !*version.IsDefaultVersion {
-				continue
-			}
-
-			doc, err := NewPolicyDocumentFromEncodedJson(*version.Document)
-			if err != nil {
-				return err
-			}
-
-			description := ""
-			if a.Mode == ModePull {
-				log.Printf("getPolicyDescription(%s)", *policyResp.Arn)
-				description, err = a.iam.getPolicyDescription(*policyResp.Arn)
-				if err != nil {
-					return err
-				}
-			}
-
-			p := Policy{
-				iamService: iamService{
-					Name: *policyResp.PolicyName,
-					Path: *policyResp.Path,
-				},
-				Description: description,
-				Policy:      doc,
-			}
-
-			a.data.Policies = append(a.data.Policies, p)
+		defaultPolicyVersion := findDefaultPolicyVersion(policyResp.PolicyVersionList)
+		doc, err := NewPolicyDocumentFromEncodedJson(*defaultPolicyVersion.Document)
+		if err != nil {
+			return err
 		}
+
+		p := Policy{
+			iamService: iamService{
+				Name: *policyResp.PolicyName,
+				Path: *policyResp.Path,
+			},
+			Description: *policyResp.Description,
+			Policy:      doc,
+		}
+
+		a.data.Policies = append(a.data.Policies, p)
 	}
 
 	return nil
+}
+
+func findDefaultPolicyVersion(versions []*iam.PolicyVersion) *iam.PolicyVersion {
+	for _, version := range versions {
+		if *version.IsDefaultVersion {
+			return version
+		}
+	}
+	panic("Expected a default policy version")
 }
 
 func (a *AwsFetcher) getAccount() (*Account, error) {

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -185,11 +185,17 @@ func (a *awsSyncCmdGenerator) updatePolicies() {
 			}
 		} else {
 			// Create policy
-			a.cmds.Add("aws", "iam", "create-policy",
+			args := []string{
+				"iam", "create-policy",
 				"--policy-name", toPolicy.Name,
 				"--path", path(toPolicy.Path),
-				"--policy-document", toPolicy.Policy.JsonString(),
-			)
+			}
+			if toPolicy.Description != "" {
+				args = append(args, "--description", toPolicy.Description)
+			}
+			// document last, for easier reading by end-user
+			args = append(args, "--policy-document", toPolicy.Policy.JsonString())
+			a.cmds.Add("aws", args...)
 		}
 	}
 }

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -177,11 +177,19 @@ func (a *awsSyncCmdGenerator) updatePolicies() {
 		if found, fromPolicy := a.from.FindPolicyByName(toPolicy.Name, toPolicy.Path); found {
 			// Update policy
 			if fromPolicy.Policy.JsonString() != toPolicy.Policy.JsonString() {
-				a.cmds.Add("aws", "iam", "create-policy-version", "--policy-arn", Arn(toPolicy, a.to.Account), "--set-as-default", "--policy-document", toPolicy.Policy.JsonString())
+				a.cmds.Add("aws", "iam", "create-policy-version",
+					"--policy-arn", Arn(toPolicy, a.to.Account),
+					"--set-as-default",
+					"--policy-document", toPolicy.Policy.JsonString(),
+				)
 			}
 		} else {
 			// Create policy
-			a.cmds.Add("aws", "iam", "create-policy", "--policy-name", toPolicy.Name, "--path", path(toPolicy.Path), "--policy-document", toPolicy.Policy.JsonString())
+			a.cmds.Add("aws", "iam", "create-policy",
+				"--policy-name", toPolicy.Name,
+				"--path", path(toPolicy.Path),
+				"--policy-document", toPolicy.Policy.JsonString(),
+			)
 		}
 	}
 }

--- a/iamy/iam.go
+++ b/iamy/iam.go
@@ -43,6 +43,14 @@ func (c *iamClient) getAccountAuthorizationDetailsResponses(input *iam.GetAccoun
 	return responses, nil
 }
 
+func (c *iamClient) getPolicyDescription(arn string) (string, error) {
+	resp, err := c.GetPolicy(&iam.GetPolicyInput{PolicyArn: &arn})
+	if err != nil {
+		return "", err
+	}
+	return *resp.Policy.Description, nil
+}
+
 func (c *iamClient) MustGetNonDefaultPolicyVersions(policyArn string) []string {
 	listPolicyVersions, err := c.ListPolicyVersions(&iam.ListPolicyVersionsInput{
 		PolicyArn: aws.String(policyArn),

--- a/iamy/iam.go
+++ b/iamy/iam.go
@@ -45,10 +45,10 @@ func (c *iamClient) getAccountAuthorizationDetailsResponses(input *iam.GetAccoun
 
 func (c *iamClient) getPolicyDescription(arn string) (string, error) {
 	resp, err := c.GetPolicy(&iam.GetPolicyInput{PolicyArn: &arn})
-	if err != nil {
-		return "", err
+	if err == nil && resp.Policy.Description != nil {
+		return *resp.Policy.Description, nil
 	}
-	return *resp.Policy.Description, nil
+	return "", err
 }
 
 func (c *iamClient) MustGetNonDefaultPolicyVersions(policyArn string) []string {

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -93,8 +93,9 @@ type InlinePolicy struct {
 }
 
 type Policy struct {
-	iamService `json:"-"`
-	Policy     *PolicyDocument `json:"Policy"`
+	iamService  `json:"-"`
+	Description string          `json:"Description,omitempty"`
+	Policy      *PolicyDocument `json:"Policy"`
 }
 
 func (p Policy) ResourceType() string {

--- a/pull.go
+++ b/pull.go
@@ -12,7 +12,7 @@ type PullCommandInput struct {
 }
 
 func PullCommand(ui Ui, input PullCommandInput) {
-	aws := iamy.AwsFetcher{}
+	aws := iamy.AwsFetcher{Mode: iamy.ModePull}
 	data, err := aws.Fetch()
 	if err != nil {
 		ui.Error.Fatal(fmt.Printf("%s", err))

--- a/pull.go
+++ b/pull.go
@@ -12,7 +12,7 @@ type PullCommandInput struct {
 }
 
 func PullCommand(ui Ui, input PullCommandInput) {
-	aws := iamy.AwsFetcher{Mode: iamy.ModePull}
+	aws := iamy.AwsFetcher{}
 	data, err := aws.Fetch()
 	if err != nil {
 		ui.Error.Fatal(fmt.Printf("%s", err))

--- a/push.go
+++ b/push.go
@@ -19,7 +19,7 @@ func PushCommand(ui Ui, input PushCommandInput) {
 	yaml := iamy.YamlLoadDumper{
 		Dir: input.Dir,
 	}
-	aws := iamy.AwsFetcher{}
+	aws := iamy.AwsFetcher{Mode: iamy.ModePush}
 
 	allDataFromYaml, err := yaml.Load()
 	if err != nil {

--- a/push.go
+++ b/push.go
@@ -19,7 +19,9 @@ func PushCommand(ui Ui, input PushCommandInput) {
 	yaml := iamy.YamlLoadDumper{
 		Dir: input.Dir,
 	}
-	aws := iamy.AwsFetcher{Mode: iamy.ModePush}
+	aws := iamy.AwsFetcher{
+		SkipFetchingPolicyDescriptions: true,
+	}
 
 	allDataFromYaml, err := yaml.Load()
 	if err != nil {


### PR DESCRIPTION
Support the Description attribute on IAM policies. Resolves https://github.com/99designs/iamy/issues/26; see that issue for more background.

* When `iamy pull` fetches new and existing policies, it writes a top-level `Description` field to the YAML file if present.
* When `iamy push` creates new policies, it sets the description from the new top-level `Description` field if present.
* When `iamy push` updates existing policies, the local YAML description is ignored because AWS policy descriptions are immutable.

Note this adds a [GetPolicy](https://godoc.org/github.com/aws/aws-sdk-go/service/iam#IAM.GetPolicy) AWS API call per policy to `iamy pull`, but not to `iamy push`. If this is considered too slow a goroutine concurrency pool could be added.