### PR TITLE
Remove excess policy versions to avoid service limits

### DIFF
--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -246,7 +246,7 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 				}
 			}
 		}
-                defaultPolicy.OldestVersion = oldestVersionId
+		defaultPolicy.OldestVersion = oldestVersionId
 		a.data.Policies = append(a.data.Policies, defaultPolicy)
 	}
 

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"regexp"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -208,29 +209,45 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 	}
 
 	for _, policyResp := range resp.Policies {
+                oldestVersionDate := time.Now()
+                oldestVersionId := "v1"
+                var defaultPolicy Policy
+
 		if cfnResourceRegexp.MatchString(*policyResp.PolicyName) {
 			log.Printf("Skipping CloudFormation generated policy %s", *policyResp.PolicyName)
 			continue
 		}
 
 		for _, version := range policyResp.PolicyVersionList {
+                        currentVersionDate := *version.CreateDate
+                        currentVersionId := *version.VersionId
+
 			if *version.IsDefaultVersion {
 				doc, err := NewPolicyDocumentFromEncodedJson(*version.Document)
 				if err != nil {
 					return err
 				}
 
-				p := Policy{
+
+				defaultPolicy = Policy{
 					iamService: iamService{
 						Name: *policyResp.PolicyName,
 						Path: *policyResp.Path,
 					},
+					OldestVersion: "UNKNOWN",
+					NumberOfVersions: len(policyResp.PolicyVersionList),
 					Policy: doc,
 				}
 
-				a.data.Policies = append(a.data.Policies, p)
+			} else {
+				if oldestVersionDate.After(currentVersionDate) {
+					oldestVersionDate = currentVersionDate
+					oldestVersionId = currentVersionId
+				}
 			}
 		}
+                defaultPolicy.OldestVersion = oldestVersionId
+	        a.data.Policies = append(a.data.Policies, defaultPolicy)
 	}
 
 	return nil

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -247,7 +247,7 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 			}
 		}
                 defaultPolicy.OldestVersion = oldestVersionId
-	        a.data.Policies = append(a.data.Policies, defaultPolicy)
+		a.data.Policies = append(a.data.Policies, defaultPolicy)
 	}
 
 	return nil

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -178,7 +178,7 @@ func (a *awsSyncCmdGenerator) updatePolicies() {
 			// Update policy
 			if fromPolicy.Policy.JsonString() != toPolicy.Policy.JsonString() {
                                 if fromPolicy.NumberOfVersions == 5 {
-				    a.cmds.Add("aws", "iam", "delete-policy-version", "--policy-arn", Arn(toPolicy, a.to.Account),  "--policy-version", fromPolicy.OldestVersion)
+					a.cmds.Add("aws", "iam", "delete-policy-version", "--policy-arn", Arn(toPolicy, a.to.Account),  "--policy-version", fromPolicy.OldestVersion)
                                 }
 				a.cmds.Add("aws", "iam", "create-policy-version", "--policy-arn", Arn(toPolicy, a.to.Account), "--set-as-default", "--policy-document", toPolicy.Policy.JsonString())
 			}

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -177,6 +177,9 @@ func (a *awsSyncCmdGenerator) updatePolicies() {
 		if found, fromPolicy := a.from.FindPolicyByName(toPolicy.Name, toPolicy.Path); found {
 			// Update policy
 			if fromPolicy.Policy.JsonString() != toPolicy.Policy.JsonString() {
+                                if fromPolicy.NumberOfVersions == 5 {
+				    a.cmds.Add("aws", "iam", "delete-policy-version", "--policy-arn", Arn(toPolicy, a.to.Account),  "--policy-version", fromPolicy.OldestVersion)
+                                }
 				a.cmds.Add("aws", "iam", "create-policy-version", "--policy-arn", Arn(toPolicy, a.to.Account), "--set-as-default", "--policy-document", toPolicy.Policy.JsonString())
 			}
 		} else {

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -94,6 +94,8 @@ type InlinePolicy struct {
 
 type Policy struct {
 	iamService `json:"-"`
+	NumberOfVersions int
+	OldestVersion string
 	Policy     *PolicyDocument `json:"Policy"`
 }
 


### PR DESCRIPTION
AWS has a default limit of 5 policy versions, it can perhaps be bumped but it's not listed in their support requests.

So this attempts to delete the oldest policy version when we hit the limit of 5, it doesn't try
and be clever and detect the error, it's just hard coded for now.

It does this by decorating the Policy struct with a couple of attributes and maintains them when iterating over the lists of policy versions.

When emitting the diff it add a policy-version-delete command if it's required.

Attempts to address:  https://github.com/99designs/iamy/issues/21
