### PR TITLE
Remove excess policy versions to avoid service limits

### DIFF
--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -257,8 +257,10 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 				Name: *policyResp.PolicyName,
 				Path: *policyResp.Path,
 			},
-			Description: *policyResp.Description,
-			Policy:      doc,
+			Description:      *policyResp.Description,
+			oldestVersionId:  findOldestPolicyVersionId(policyResp.PolicyVersionList),
+			numberOfVersions: len(policyResp.PolicyVersionList),
+			Policy:           doc,
 		}
 
 		a.data.Policies = append(a.data.Policies, p)
@@ -274,6 +276,16 @@ func findDefaultPolicyVersion(versions []*iam.PolicyVersion) *iam.PolicyVersion 
 		}
 	}
 	panic("Expected a default policy version")
+}
+
+func findOldestPolicyVersionId(versions []*iam.PolicyVersion) string {
+	oldest := versions[0]
+	for _, version := range versions[1:] {
+		if version.CreateDate.Before(*oldest.CreateDate) {
+			oldest = version
+		}
+	}
+	return *oldest.VersionId
 }
 
 func (a *AwsFetcher) getAccount() (*Account, error) {

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -93,9 +93,11 @@ type InlinePolicy struct {
 }
 
 type Policy struct {
-	iamService  `json:"-"`
-	Description string          `json:"Description,omitempty"`
-	Policy      *PolicyDocument `json:"Policy"`
+	iamService       `json:"-"`
+	numberOfVersions int
+	oldestVersionId  string
+	Description      string          `json:"Description,omitempty"`
+	Policy           *PolicyDocument `json:"Policy"`
 }
 
 func (p Policy) ResourceType() string {


### PR DESCRIPTION
Rebases #29
Fixes #21 

AWS has a default limit of 5 policy versions, it can perhaps be bumped but it's not listed in their support requests.

So this attempts to delete the oldest policy version when we hit the limit of 5, it doesn't try
and be clever and detect the error, it's just hard coded for now.

It does this by decorating the Policy struct with a couple of attributes and maintains them when iterating over the lists of policy versions.

When emitting the diff it add a policy-version-delete command if it's required.

