### PR TITLE
Delete entities last

### DIFF
--- a/iamy/awsdiff_test.go
+++ b/iamy/awsdiff_test.go
@@ -1,0 +1,46 @@
+package iamy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func loadDataFrom(p string) *AccountData {
+	d, err := os.Getwd()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	yamlLoader := YamlLoadDumper{
+		Dir: filepath.Join(d, "testdata", "awsdiff", p),
+	}
+
+	dd, err := yamlLoader.Load()
+	if err != nil {
+		panic(err.Error())
+	}
+	return &dd[0]
+}
+
+func TestPolicyIsDetachedFromRoleBeforeUpdate(t *testing.T) {
+	localData := loadDataFrom("testcase1-local")
+	remoteData := loadDataFrom("testcase1-remote")
+	awsCmds := AwsCliCmdsForSync(remoteData, localData)
+
+	expected := strings.Join([]string{
+		"aws iam detach-role-policy --role-name testrole --policy-arn arn:aws:iam::123:policy/test",
+		"aws iam delete-policy --policy-arn arn:aws:iam::123:policy/test",
+	}, "\n")
+	actual := awsCmds.String()
+
+	if actual != expected {
+
+		t.Errorf(`Expected:
+%v
+Actual:
+%v`, expected, actual)
+
+	}
+}

--- a/iamy/testdata/awsdiff/testcase1-local/myalias-123/iam/role/testrole.yaml
+++ b/iamy/testdata/awsdiff/testcase1-local/myalias-123/iam/role/testrole.yaml
@@ -1,0 +1,8 @@
+AssumeRolePolicyDocument:
+  Statement:
+  - Action: sts:AssumeRole
+    Effect: Allow
+    Principal:
+      AWS: arn:aws:iam::123:root
+    Sid: ""
+  Version: 2012-10-17

--- a/iamy/testdata/awsdiff/testcase1-remote/myalias-123/iam/policy/test.yaml
+++ b/iamy/testdata/awsdiff/testcase1-remote/myalias-123/iam/policy/test.yaml
@@ -1,0 +1,7 @@
+Policy:
+  Statement:
+  - Action:
+    - ec2:Describe*
+    Effect: Allow
+    Resource: '*'
+  Version: 2012-10-17

--- a/iamy/testdata/awsdiff/testcase1-remote/myalias-123/iam/role/testrole.yaml
+++ b/iamy/testdata/awsdiff/testcase1-remote/myalias-123/iam/role/testrole.yaml
@@ -1,0 +1,10 @@
+AssumeRolePolicyDocument:
+  Statement:
+  - Action: sts:AssumeRole
+    Effect: Allow
+    Principal:
+      AWS: arn:aws:iam::123:root
+    Sid: ""
+  Version: 2012-10-17
+Policies:
+- test


### PR DESCRIPTION
Fixes #22 

Updates the operation order so that we only delete entities when other dependant entities have been updated.

Also adds some tests for awsdiff.go