### PR TITLE
Add role description 

### DIFF
--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -152,6 +152,8 @@ func (a *AwsFetcher) asyncMarshallPolicyDescriptionIntoStruct(policyArn string, 
 	a.descriptionFetchWaitGroup.Add(1)
 	go func() {
 		defer a.descriptionFetchWaitGroup.Done()
+		log.Println("Fetching policy description for", policyArn)
+
 		var err error
 		*target, err = a.iam.getPolicyDescription(policyArn)
 		if err != nil {
@@ -164,6 +166,8 @@ func (a *AwsFetcher) asyncMarshallRoleDescriptionIntoStruct(roleName string, tar
 	a.descriptionFetchWaitGroup.Add(1)
 	go func() {
 		defer a.descriptionFetchWaitGroup.Done()
+		log.Println("Fetching role description for", roleName)
+
 		var err error
 		*target, err = a.iam.getRoleDescription(roleName)
 		if err != nil {
@@ -245,7 +249,7 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 			return err
 		}
 
-		a.data.Roles = append(a.data.Roles, role)
+		a.data.addRole(&role)
 	}
 
 	for _, policyResp := range resp.Policies {
@@ -275,7 +279,7 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 			a.asyncMarshallPolicyDescriptionIntoStruct(*policyResp.Arn, &p.Description)
 		}
 
-		a.data.Policies = append(a.data.Policies, p)
+		a.data.addPolicy(&p)
 	}
 
 	a.descriptionFetchWaitGroup.Wait()

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -14,14 +14,17 @@ var cfnResourceRegexp = regexp.MustCompile(`-[A-Z0-9]{10,20}$`)
 
 // AwsFetcher fetches account data from AWS
 type AwsFetcher struct {
-	// As Policy descriptions are immutable, you can skip updating them
+	// As Policy and Role descriptions are immutable, we can skip fetching them
 	// when pushing to AWS
-	SkipFetchingPolicyDescriptions bool
+	SkipFetchingPolicyAndRoleDescriptions bool
 
 	iam     *iamClient
 	s3      *s3Client
 	account *Account
 	data    AccountData
+
+	descriptionFetchWaitGroup sync.WaitGroup
+	descriptionFetchError     error
 }
 
 func (a *AwsFetcher) init() error {
@@ -145,36 +148,31 @@ func (a *AwsFetcher) populateInlinePolicies(source []*iam.PolicyDetail, target *
 	return nil
 }
 
-func (a *AwsFetcher) fetchPolicyDescriptions(resp *iam.GetAccountAuthorizationDetailsOutput) error {
-	log.Println("Fetching Policy descriptions")
-	var err error
-	var wg sync.WaitGroup
-	for _, policyResp := range resp.Policies {
-		if cfnResourceRegexp.MatchString(*policyResp.PolicyName) {
-			continue
+func (a *AwsFetcher) asyncMarshallPolicyDescriptionIntoStruct(policyArn string, target *string) {
+	a.descriptionFetchWaitGroup.Add(1)
+	go func() {
+		defer a.descriptionFetchWaitGroup.Done()
+		var err error
+		*target, err = a.iam.getPolicyDescription(policyArn)
+		if err != nil {
+			a.descriptionFetchError = err
 		}
+	}()
+}
 
-		wg.Add(1)
-		go func(policy *iam.ManagedPolicyDetail) {
-			defer wg.Done()
-			desc, fetchErr := a.iam.getPolicyDescription(*policy.Arn)
-			policy.SetDescription(desc)
-			if fetchErr != nil {
-				err = fetchErr
-			}
-		}(policyResp)
-
-	}
-	wg.Wait()
-
-	return err
+func (a *AwsFetcher) asyncMarshallRoleDescriptionIntoStruct(roleName string, target *string) {
+	a.descriptionFetchWaitGroup.Add(1)
+	go func() {
+		defer a.descriptionFetchWaitGroup.Done()
+		var err error
+		*target, err = a.iam.getRoleDescription(roleName)
+		if err != nil {
+			a.descriptionFetchError = err
+		}
+	}()
 }
 
 func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOutput) error {
-	if !a.SkipFetchingPolicyDescriptions {
-		a.fetchPolicyDescriptions(resp)
-	}
-
 	for _, userResp := range resp.UserDetailList {
 		if cfnResourceRegexp.MatchString(*userResp.UserName) {
 			log.Printf("Skipping CloudFormation generated user %s", *userResp.UserName)
@@ -231,6 +229,10 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 			Path: *roleResp.Path,
 		}}
 
+		if !a.SkipFetchingPolicyAndRoleDescriptions {
+			a.asyncMarshallRoleDescriptionIntoStruct(*roleResp.RoleName, &role.Description)
+		}
+
 		var err error
 		role.AssumeRolePolicyDocument, err = NewPolicyDocumentFromEncodedJson(*roleResp.AssumeRolePolicyDocument)
 		if err != nil {
@@ -268,14 +270,17 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 			nondefaultVersionIds: findNonDefaultPolicyVersionIds(policyResp.PolicyVersionList),
 			Policy:               doc,
 		}
-		if policyResp.Description != nil {
-			p.Description = *policyResp.Description
+
+		if !a.SkipFetchingPolicyAndRoleDescriptions {
+			a.asyncMarshallPolicyDescriptionIntoStruct(*policyResp.Arn, &p.Description)
 		}
 
 		a.data.Policies = append(a.data.Policies, p)
 	}
 
-	return nil
+	a.descriptionFetchWaitGroup.Wait()
+
+	return a.descriptionFetchError
 }
 
 func findDefaultPolicyVersion(versions []*iam.PolicyVersion) *iam.PolicyVersion {

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -148,7 +148,7 @@ func (a *AwsFetcher) populateInlinePolicies(source []*iam.PolicyDetail, target *
 	return nil
 }
 
-func (a *AwsFetcher) asyncMarshallPolicyDescriptionIntoStruct(policyArn string, target *string) {
+func (a *AwsFetcher) asyncMarshalPolicyDescriptionIntoStruct(policyArn string, target *string) {
 	a.descriptionFetchWaitGroup.Add(1)
 	go func() {
 		defer a.descriptionFetchWaitGroup.Done()
@@ -162,7 +162,7 @@ func (a *AwsFetcher) asyncMarshallPolicyDescriptionIntoStruct(policyArn string, 
 	}()
 }
 
-func (a *AwsFetcher) asyncMarshallRoleDescriptionIntoStruct(roleName string, target *string) {
+func (a *AwsFetcher) asyncMarshalRoleDescriptionIntoStruct(roleName string, target *string) {
 	a.descriptionFetchWaitGroup.Add(1)
 	go func() {
 		defer a.descriptionFetchWaitGroup.Done()
@@ -234,7 +234,7 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 		}}
 
 		if !a.SkipFetchingPolicyAndRoleDescriptions {
-			a.asyncMarshallRoleDescriptionIntoStruct(*roleResp.RoleName, &role.Description)
+			a.asyncMarshalRoleDescriptionIntoStruct(*roleResp.RoleName, &role.Description)
 		}
 
 		var err error
@@ -276,7 +276,7 @@ func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOut
 		}
 
 		if !a.SkipFetchingPolicyAndRoleDescriptions {
-			a.asyncMarshallPolicyDescriptionIntoStruct(*policyResp.Arn, &p.Description)
+			a.asyncMarshalPolicyDescriptionIntoStruct(*policyResp.Arn, &p.Description)
 		}
 
 		a.data.addPolicy(&p)

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -228,7 +228,16 @@ func (a *awsSyncCmdGenerator) updateRoles() {
 
 		} else {
 			// Create role
-			a.cmds.Add("aws", "iam", "create-role", "--role-name", toRole.Name, "--path", path(toRole.Path), "--assume-role-policy-document", toRole.AssumeRolePolicyDocument.JsonString())
+			args := []string{
+				"iam", "create-role",
+				"--role-name", toRole.Name,
+				"--path", path(toRole.Path),
+			}
+			if toRole.Description != "" {
+				args = append(args, "--description", toRole.Description)
+			}
+			args = append(args, "--assume-role-policy-document", toRole.AssumeRolePolicyDocument.JsonString())
+			a.cmds.Add("aws", args...)
 
 			// add new inline policies
 			for _, ip := range toRole.InlinePolicies {

--- a/iamy/iam.go
+++ b/iamy/iam.go
@@ -25,6 +25,14 @@ func (c *iamClient) getPolicyDescription(arn string) (string, error) {
 	return "", err
 }
 
+func (c *iamClient) getRoleDescription(name string) (string, error) {
+	resp, err := c.GetRole(&iam.GetRoleInput{RoleName: &name})
+	if err == nil && resp.Role.Description != nil {
+		return *resp.Role.Description, nil
+	}
+	return "", err
+}
+
 func (c *iamClient) MustGetSecurityCredsForUser(username string) (accessKeyIds, mfaIds []string, hasLoginProfile bool) {
 	// access keys
 	listUsersResp, err := c.ListAccessKeys(&iam.ListAccessKeysInput{

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -107,6 +107,7 @@ func (p Policy) ResourceType() string {
 
 type Role struct {
 	iamService               `json:"-"`
+	Description              string          `json:"Description,omitempty"`
 	AssumeRolePolicyDocument *PolicyDocument `json:"AssumeRolePolicyDocument"`
 	InlinePolicies           []InlinePolicy  `json:"InlinePolicies,omitempty"`
 	Policies                 []string        `json:"Policies,omitempty"`

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -142,8 +142,8 @@ type AccountData struct {
 	Account        *Account
 	Users          []User
 	Groups         []Group
-	Roles          []Role
-	Policies       []Policy
+	Roles          []*Role
+	Policies       []*Policy
 	BucketPolicies []BucketPolicy
 }
 
@@ -152,8 +152,8 @@ func NewAccountData(account string) *AccountData {
 		Account:  NewAccountFromString(account),
 		Users:    []User{},
 		Groups:   []Group{},
-		Roles:    []Role{},
-		Policies: []Policy{},
+		Roles:    []*Role{},
+		Policies: []*Policy{},
 	}
 }
 
@@ -165,11 +165,11 @@ func (a *AccountData) addGroup(g Group) {
 	a.Groups = append(a.Groups, g)
 }
 
-func (a *AccountData) addRole(r Role) {
+func (a *AccountData) addRole(r *Role) {
 	a.Roles = append(a.Roles, r)
 }
 
-func (a *AccountData) addPolicy(p Policy) {
+func (a *AccountData) addPolicy(p *Policy) {
 	a.Policies = append(a.Policies, p)
 }
 
@@ -200,7 +200,7 @@ func (a *AccountData) FindGroupByName(name, path string) (bool, *Group) {
 func (a *AccountData) FindRoleByName(name, path string) (bool, *Role) {
 	for _, r := range a.Roles {
 		if r.Name == name && r.Path == path {
-			return true, &r
+			return true, r
 		}
 	}
 
@@ -210,7 +210,7 @@ func (a *AccountData) FindRoleByName(name, path string) (bool, *Role) {
 func (a *AccountData) FindPolicyByName(name, path string) (bool, *Policy) {
 	for _, p := range a.Policies {
 		if p.Name == name && p.Path == path {
-			return true, &p
+			return true, p
 		}
 	}
 

--- a/iamy/yaml.go
+++ b/iamy/yaml.go
@@ -101,11 +101,11 @@ func (a *YamlLoadDumper) Load() ([]AccountData, error) {
 			case "iam/role":
 				r := Role{iamService: nameAndPath}
 				err = a.unmarshalYamlFile(fp, &r)
-				accounts[accountid].addRole(r)
+				accounts[accountid].addRole(&r)
 			case "iam/policy":
 				p := Policy{iamService: nameAndPath}
 				err = a.unmarshalYamlFile(fp, &p)
-				accounts[accountid].addPolicy(p)
+				accounts[accountid].addPolicy(&p)
 			case "s3":
 				bp := BucketPolicy{BucketName: name}
 				err = a.unmarshalYamlFile(fp, &bp)

--- a/push.go
+++ b/push.go
@@ -20,7 +20,7 @@ func PushCommand(ui Ui, input PushCommandInput) {
 		Dir: input.Dir,
 	}
 	aws := iamy.AwsFetcher{
-		SkipFetchingPolicyDescriptions: true,
+		SkipFetchingPolicyAndRoleDescriptions: true,
 	}
 
 	allDataFromYaml, err := yaml.Load()


### PR DESCRIPTION
Adds of Role description to the yaml file dump and `create-role` command

Also simplifies our fetching strategy by marshalling description data directly into the Role and Policy struct