### PR TITLE
fix version-id parameter when deleting a policy version

### DIFF
--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -198,7 +198,7 @@ func (a *awsSyncCmdGenerator) updatePolicies() {
 				if fromPolicy.numberOfVersions >= MaxAllowedPolicyVersions {
 					a.cmds.Add("aws", "iam", "delete-policy-version",
 						"--policy-arn", Arn(toPolicy, a.to.Account),
-						"--policy-version", fromPolicy.oldestVersionId)
+						"--version-id", fromPolicy.oldestVersionId)
 				}
 
 				a.cmds.Add("aws", "iam", "create-policy-version",


### PR DESCRIPTION
It seems that `--policy-version` is not (or no longer) a thing as referenced in the documentation here: http://docs.aws.amazon.com/cli/latest/reference/iam/delete-policy-version.html
As such this was failing when trying to run that command.
This PR changes from `--policy-version` to the correct `--version-id`