### PR TITLE
Manage IAM instance profiles

### DIFF
--- a/iamy.go
+++ b/iamy.go
@@ -12,7 +12,7 @@ import (
 var (
 	Version    string = "dev"
 	defaultDir string
-	dryRun *bool
+	dryRun     *bool
 )
 
 type logWriter struct{ *log.Logger }

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -201,9 +201,9 @@ func (a *AwsFetcher) populateInstanceProfileData(resp *iam.ListInstanceProfilesO
 			Path: *profileResp.Path,
 		}}
 		if len(profileResp.Roles) > 0 {
-			for _, roleResp := range  profileResp.Roles {
+			for _, roleResp := range profileResp.Roles {
 				role := *(roleResp.RoleName)
-				profile.Roles = append (profile.Roles, role)
+				profile.Roles = append(profile.Roles, role)
 			}
 		}
 		a.data.InstanceProfiles = append(a.data.InstanceProfiles, &profile)

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -200,11 +200,9 @@ func (a *AwsFetcher) populateInstanceProfileData(resp *iam.ListInstanceProfilesO
 			Name: *profileResp.InstanceProfileName,
 			Path: *profileResp.Path,
 		}}
-		if len(profileResp.Roles) > 0 {
-			for _, roleResp := range profileResp.Roles {
-				role := *(roleResp.RoleName)
-				profile.Roles = append(profile.Roles, role)
-			}
+		for _, roleResp := range profileResp.Roles {
+			role := *(roleResp.RoleName)
+			profile.Roles = append(profile.Roles, role)
 		}
 		a.data.InstanceProfiles = append(a.data.InstanceProfiles, &profile)
         }

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -105,6 +105,7 @@ func (a *AwsFetcher) fetchS3Data() error {
 }
 func (a *AwsFetcher) fetchIamData() error {
 	var populateIamDataErr error
+	var populateInstanceProfileErr error
 	err := a.iam.GetAccountAuthorizationDetailsPages(
 		&iam.GetAccountAuthorizationDetailsInput{
 			Filter: aws.StringSlice([]string{
@@ -119,7 +120,6 @@ func (a *AwsFetcher) fetchIamData() error {
 			if populateIamDataErr != nil {
 				return false
 			}
-
 			return true
 		},
 	)
@@ -129,7 +129,21 @@ func (a *AwsFetcher) fetchIamData() error {
 	if err != nil {
 		return err
 	}
-
+	// Fetch instance profiles
+	err = a.iam.ListInstanceProfilesPages(&iam.ListInstanceProfilesInput{},
+		func(resp *iam.ListInstanceProfilesOutput, lastPage bool) bool {
+			populateInstanceProfileErr = a.populateInstanceProfileData(resp)
+			if populateInstanceProfileErr != nil {
+				return false
+			}
+			return true
+		})
+	if populateInstanceProfileErr != nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -174,6 +188,27 @@ func (a *AwsFetcher) marshalRoleDescriptionAsync(roleName string, target *string
 			a.descriptionFetchError = err
 		}
 	}()
+}
+
+func (a *AwsFetcher) populateInstanceProfileData(resp *iam.ListInstanceProfilesOutput) error {
+	for _, profileResp := range resp.InstanceProfiles {
+		if cfnResourceRegexp.MatchString(*profileResp.InstanceProfileName) {
+			log.Printf("Skipping CloudFormation generated instance profile %s", *profileResp.InstanceProfileName)
+			continue
+		}
+		profile := InstanceProfile{iamService: iamService{
+			Name: *profileResp.InstanceProfileName,
+			Path: *profileResp.Path,
+		}}
+		if len(profileResp.Roles) > 0 {
+			for _, roleResp := range  profileResp.Roles {
+				role := *(roleResp.RoleName)
+				profile.Roles = append (profile.Roles, role)
+			}
+		}
+		a.data.InstanceProfiles = append(a.data.InstanceProfiles, &profile)
+        }
+	return nil
 }
 
 func (a *AwsFetcher) populateIamData(resp *iam.GetAccountAuthorizationDetailsOutput) error {

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -205,7 +205,7 @@ func (a *AwsFetcher) populateInstanceProfileData(resp *iam.ListInstanceProfilesO
 			profile.Roles = append(profile.Roles, role)
 		}
 		a.data.InstanceProfiles = append(a.data.InstanceProfiles, &profile)
-        }
+	}
 	return nil
 }
 

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -430,7 +430,7 @@ func (a *awsSyncCmdGenerator) updateInstanceProfiles() {
                         }
 		} else {
                         // Create instance profile
-			a.cmds.Add("aws","create-instance-profile","--instance-profile-name",toInstanceProfile.Name,"--path",path(toInstanceProfile.Path))
+			a.cmds.Add("aws", "create-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--path", path(toInstanceProfile.Path))
                         for _, role := range toInstanceProfile.Roles {
                                 a.cmds.Add("aws", "iam", "add-role-to-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--role-name", role)
                         }

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -420,20 +420,20 @@ func (a *awsSyncCmdGenerator) updateInstanceProfiles() {
 	for _, toInstanceProfile := range a.to.InstanceProfiles {
 		if found, fromInstanceProfile := a.from.FindInstanceProfileByName(toInstanceProfile.Name, toInstanceProfile.Path); found {
 			// remove old roles from instance profile
-                        for _, role := range stringSetDifference(fromInstanceProfile.Roles, toInstanceProfile.Roles) {
-                                a.cmds.Add("aws", "iam", "remove-role-from-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--role-name", role)
+			for _, role := range stringSetDifference(fromInstanceProfile.Roles, toInstanceProfile.Roles) {
+				a.cmds.Add("aws", "iam", "remove-role-from-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--role-name", role)
 			}
 
-                        // add new roles to instance profile
-                        for _, role := range stringSetDifference(toInstanceProfile.Roles, fromInstanceProfile.Roles) {
-                                a.cmds.Add("aws", "iam", "add-role-to-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--role-name", role)
-                        }
+			// add new roles to instance profile
+			for _, role := range stringSetDifference(toInstanceProfile.Roles, fromInstanceProfile.Roles) {
+				a.cmds.Add("aws", "iam", "add-role-to-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--role-name", role)
+			}
 		} else {
-                        // Create instance profile
+			// Create instance profile
 			a.cmds.Add("aws", "create-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--path", path(toInstanceProfile.Path))
-                        for _, role := range toInstanceProfile.Roles {
-                                a.cmds.Add("aws", "iam", "add-role-to-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--role-name", role)
-                        }
+			for _, role := range toInstanceProfile.Roles {
+				a.cmds.Add("aws", "iam", "add-role-to-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--role-name", role)
+			}
 		}
 	}
 }

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -186,6 +186,12 @@ func (a *awsSyncCmdGenerator) deleteOldEntities() {
 				"--policy-arn", Arn(fromPolicy, a.to.Account))
 		}
 	}
+	for _, fromInstanceProfile := range a.from.InstanceProfiles {
+		if found, _ := a.to.FindInstanceProfileByName(fromInstanceProfile.Name, fromInstanceProfile.Path); !found {
+			a.cmds.Add("aws", "iam", "delete-instance-profile",
+				"--instance-profile-name", fromInstanceProfile.Name)
+		}
+	}
 }
 
 func (a *awsSyncCmdGenerator) updatePolicies() {
@@ -409,6 +415,28 @@ func (a *awsSyncCmdGenerator) updateUsers() {
 		}
 	}
 }
+func (a *awsSyncCmdGenerator) updateInstanceProfiles() {
+	// update instance profiles
+	for _, toInstanceProfile := range a.to.InstanceProfiles {
+		if found, fromInstanceProfile := a.from.FindInstanceProfileByName(toInstanceProfile.Name, toInstanceProfile.Path); found {
+			// remove old roles from instance profile
+                        for _, role := range stringSetDifference(fromInstanceProfile.Roles, toInstanceProfile.Roles) {
+                                a.cmds.Add("aws", "iam", "remove-role-from-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--role-name", role)
+			}
+
+                        // add new roles to instance profile
+                        for _, role := range stringSetDifference(toInstanceProfile.Roles, fromInstanceProfile.Roles) {
+                                a.cmds.Add("aws", "iam", "add-role-to-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--role-name", role)
+                        }
+		} else {
+                        // Create instance profile
+			a.cmds.Add("aws","create-instance-profile","--instance-profile-name",toInstanceProfile.Name,"--path",path(toInstanceProfile.Path))
+                        for _, role := range toInstanceProfile.Roles {
+                                a.cmds.Add("aws", "iam", "add-role-to-instance-profile", "--instance-profile-name", toInstanceProfile.Name, "--role-name", role)
+                        }
+		}
+	}
+}
 
 func (a *awsSyncCmdGenerator) updateBucketPolicies() {
 	for _, fromBucketPolicy := range a.from.BucketPolicies {
@@ -437,6 +465,7 @@ func (a *awsSyncCmdGenerator) GenerateCmds() CmdList {
 	a.updateRoles()
 	a.updateGroups()
 	a.updateUsers()
+	a.updateInstanceProfiles()
 	a.updateBucketPolicies()
 	a.deleteOldEntities()
 

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -113,6 +113,15 @@ type Role struct {
 	Policies                 []string        `json:"Policies,omitempty"`
 }
 
+type InstanceProfile struct {
+	iamService		`json:"-"`
+	Roles			[]string	`json:"Roles,omitempty"`
+}
+
+func (ip InstanceProfile) ResourceType() string {
+	return "instance_profile"
+}
+
 func (r Role) ResourceType() string {
 	return "role"
 }
@@ -145,6 +154,7 @@ type AccountData struct {
 	Roles          []*Role
 	Policies       []*Policy
 	BucketPolicies []*BucketPolicy
+	InstanceProfiles []*InstanceProfile
 }
 
 func NewAccountData(account string) *AccountData {
@@ -154,6 +164,7 @@ func NewAccountData(account string) *AccountData {
 		Groups:   []*Group{},
 		Roles:    []*Role{},
 		Policies: []*Policy{},
+		InstanceProfiles: []*InstanceProfile{},
 	}
 }
 
@@ -171,6 +182,10 @@ func (a *AccountData) addRole(r *Role) {
 
 func (a *AccountData) addPolicy(p *Policy) {
 	a.Policies = append(a.Policies, p)
+}
+
+func (a *AccountData) addInstanceProfile(p *InstanceProfile) {
+	a.InstanceProfiles = append(a.InstanceProfiles, p)
 }
 
 func (a *AccountData) addBucketPolicy(bp *BucketPolicy) {
@@ -209,6 +224,16 @@ func (a *AccountData) FindRoleByName(name, path string) (bool, *Role) {
 
 func (a *AccountData) FindPolicyByName(name, path string) (bool, *Policy) {
 	for _, p := range a.Policies {
+		if p.Name == name && p.Path == path {
+			return true, p
+		}
+	}
+
+	return false, nil
+}
+
+func (a *AccountData) FindInstanceProfileByName(name, path string) (bool, *InstanceProfile) {
+	for _, p := range a.InstanceProfiles {
 		if p.Name == name && p.Path == path {
 			return true, p
 		}

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -148,22 +148,22 @@ func (bp BucketPolicy) ResourcePath() string {
 }
 
 type AccountData struct {
-	Account        *Account
-	Users          []*User
-	Groups         []*Group
-	Roles          []*Role
-	Policies       []*Policy
-	BucketPolicies []*BucketPolicy
+	Account          *Account
+	Users            []*User
+	Groups           []*Group
+	Roles            []*Role
+	Policies         []*Policy
+	BucketPolicies   []*BucketPolicy
 	InstanceProfiles []*InstanceProfile
 }
 
 func NewAccountData(account string) *AccountData {
 	return &AccountData{
-		Account:  NewAccountFromString(account),
-		Users:    []*User{},
-		Groups:   []*Group{},
-		Roles:    []*Role{},
-		Policies: []*Policy{},
+		Account:          NewAccountFromString(account),
+		Users:            []*User{},
+		Groups:           []*Group{},
+		Roles:            []*Role{},
+		Policies:         []*Policy{},
 		InstanceProfiles: []*InstanceProfile{},
 	}
 }

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -114,8 +114,8 @@ type Role struct {
 }
 
 type InstanceProfile struct {
-	iamService		`json:"-"`
-	Roles			[]string	`json:"Roles,omitempty"`
+	iamService `json:"-"`
+	Roles      []string `json:"Roles,omitempty"`
 }
 
 func (ip InstanceProfile) ResourceType() string {

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -119,7 +119,7 @@ type InstanceProfile struct {
 }
 
 func (ip InstanceProfile) ResourceType() string {
-	return "instance_profile"
+	return "instance-profile"
 }
 
 func (r Role) ResourceType() string {

--- a/iamy/yaml.go
+++ b/iamy/yaml.go
@@ -13,7 +13,7 @@ import (
 )
 
 const pathTemplateBlob = "{{.Account}}/{{.Resource.Service}}/{{.Resource.ResourceType}}{{.Resource.ResourcePath}}{{.Resource.ResourceName}}.yaml"
-const pathRegexBlob = `^(?P<account>[^/]+)/(?P<entity>(iam/user|iam/group|iam/policy|iam/role|s3))(?P<resourcepath>.*/)(?P<resourcename>[^/]+)\.yaml$`
+const pathRegexBlob = `^(?P<account>[^/]+)/(?P<entity>(iam/instance_profile|iam/user|iam/group|iam/policy|iam/role|s3))(?P<resourcepath>.*/)(?P<resourcename>[^/]+)\.yaml$`
 
 var pathTemplate = template.Must(template.New("").Parse(pathTemplateBlob))
 var pathRegex = regexp.MustCompile(pathRegexBlob)
@@ -106,6 +106,10 @@ func (a *YamlLoadDumper) Load() ([]AccountData, error) {
 				p := Policy{iamService: nameAndPath}
 				err = a.unmarshalYamlFile(fp, &p)
 				accounts[accountid].addPolicy(&p)
+			case "iam/instance_profile":
+				profile := InstanceProfile{iamService: nameAndPath}
+				err = a.unmarshalYamlFile(fp, &profile)
+				accounts[accountid].addInstanceProfile(&profile)
 			case "s3":
 				bp := BucketPolicy{BucketName: name}
 				err = a.unmarshalYamlFile(fp, &bp)
@@ -164,6 +168,12 @@ func (f *YamlLoadDumper) Dump(accountData *AccountData, canDelete bool) error {
 
 	for _, role := range accountData.Roles {
 		if err := f.writeResource(accountData.Account, role); err != nil {
+			return err
+		}
+	}
+
+	for _, profile := range accountData.InstanceProfiles {
+		if err := f.writeResource(accountData.Account, profile); err != nil {
 			return err
 		}
 	}

--- a/iamy/yaml.go
+++ b/iamy/yaml.go
@@ -13,7 +13,7 @@ import (
 )
 
 const pathTemplateBlob = "{{.Account}}/{{.Resource.Service}}/{{.Resource.ResourceType}}{{.Resource.ResourcePath}}{{.Resource.ResourceName}}.yaml"
-const pathRegexBlob = `^(?P<account>[^/]+)/(?P<entity>(iam/instance_profile|iam/user|iam/group|iam/policy|iam/role|s3))(?P<resourcepath>.*/)(?P<resourcename>[^/]+)\.yaml$`
+const pathRegexBlob = `^(?P<account>[^/]+)/(?P<entity>(iam/instance-profile|iam/user|iam/group|iam/policy|iam/role|s3))(?P<resourcepath>.*/)(?P<resourcename>[^/]+)\.yaml$`
 
 var pathTemplate = template.Must(template.New("").Parse(pathTemplateBlob))
 var pathRegex = regexp.MustCompile(pathRegexBlob)
@@ -106,7 +106,7 @@ func (a *YamlLoadDumper) Load() ([]AccountData, error) {
 				p := Policy{iamService: nameAndPath}
 				err = a.unmarshalYamlFile(fp, &p)
 				accounts[accountid].addPolicy(&p)
-			case "iam/instance_profile":
+			case "iam/instance-profile":
 				profile := InstanceProfile{iamService: nameAndPath}
 				err = a.unmarshalYamlFile(fp, &profile)
 				accounts[accountid].addInstanceProfile(&profile)


### PR DESCRIPTION
Instance profiles are a bit of a hybrid between IAM and EC2,  but if you've moved IAM management out of your cloudformation templates it feels a little weird to leave the instance profiles behind.

This PR adds the ability to manage instance profiles.

The IAM API call that is used to grab users, groups, roles, policies GetAccountAuthorizationDetails doesn't support instance profiles, so there is a bit of copy'pasta code here to use the ListInstanceProfiles API call. Sorry about that.  I suspect that this section might be ripe for  a little refactoring.  My golang is crappy enough that I haven't attempted that.

# Demo
```
$ ../bin/iamy-darwin-amd64 pull -d .
$ cd envato-platform-development-123456789012/iam/instance_profile/
$ ls -1F
EC2ReadOnly.yaml
aws-elasticbeanstalk-ec2-role.yaml
ecsInstanceRole.yaml
test/
$ cat EC2ReadOnly.yaml 
Roles:
- EC2ReadOnly
$ cp EC2ReadOnly.yaml test/testpath.yaml   # Add role to an instance profile
$ echo '{}' > EC2ReadOnly.yaml # Remove roles from an instance profile
$ cp test/testpath.yaml test/newtestpath.yaml # Create a new instance profile (with path)
$ rm HumpyIAMDBTestRole.yaml  # Remove an instance profile
$ cd ../../..
$ ../bin/iamy-darwin-amd64 push -d . --dry-run
Commands to push changes to AWS:

      aws iam remove-role-from-instance-profile --instance-profile-name EC2ReadOnly --role-name EC2ReadOnly
      aws create-instance-profile --instance-profile-name newtestpath --path /test/
      aws iam add-role-to-instance-profile --instance-profile-name newtestpath --role-name EC2ReadOnly
      aws iam add-role-to-instance-profile --instance-profile-name testpath --role-name EC2ReadOnly
      aws iam delete-instance-profile --instance-profile-name HumpyIAMDBTestRole
Dry-run mode not running aws commands
```
