### PR TITLE
Ensure consistent file path separator handling in all OS

### DIFF
--- a/iamy/yaml.go
+++ b/iamy/yaml.go
@@ -41,7 +41,7 @@ func (a *YamlLoadDumper) getFilesRecursively() ([]string, error) {
 		}
 
 		if !info.IsDir() {
-			paths = append(paths, path)
+			paths = append(paths, filepath.ToSlash(path))
 		}
 
 		return nil


### PR DESCRIPTION
Currently `iamy push` fails in Windows environments with the error `No files found for AWS Account ID`.
This is caused by Windows file paths containing backslashes - the regex matching logic and other logic within yaml.go expects file paths to have forward slashes.
We can use the `filepath.ToSlash` function to ensure the use of forward slashes as file path separators.