### PR TITLE
Handle zombie S3 buckets and dead bucket detritus 

### DIFF
--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -461,14 +461,14 @@ func (a *awsSyncCmdGenerator) updateBucketPolicies() {
 				}
 				if fromBucketPolicy.Policy.JsonString() == deletedPolicy.JsonString() {
 					isToAccountUpToDate = true
-					log.Printf("Skipping deleted bucket %s",toBucketPolicy.BucketName)
+					log.Printf("Skipping deleted bucket %s", toBucketPolicy.BucketName)
 				}
 			}
 			if !isToAccountUpToDate {
 				a.cmds.Add("aws", "s3api", "put-bucket-policy", "--bucket", toBucketPolicy.BucketName, "--policy", toBucketPolicy.Policy.JsonString())
 			}
 		} else {
-			log.Printf("Skipping non-existant bucket %s",toBucketPolicy.BucketName)
+			log.Printf("Skipping non-existant bucket %s", toBucketPolicy.BucketName)
 		}
 	}
 }

--- a/iamy/s3.go
+++ b/iamy/s3.go
@@ -113,7 +113,7 @@ func (c *s3Client) listAllBuckets() ([]*bucket, error) {
 			if err != nil {
 				if awsErr, ok := err.(awserr.Error); ok {
 					if awsErr.Code() == NoSuchBucketErrCode {
-						log.Printf("Skipped deleted but still visible bucket %s", b.name)
+						log.Printf("Skipping deleted but still visible bucket %s", b.name)
 						return
 					}
 				}


### PR DESCRIPTION
S3 buckets are weird eventually consistent things.

We found that occasionally a deleted bucket, will persist in the results of a listallmybuckets for hours after it has been removed.  This caused iamy to throw an error and exit, when trying to get details about the zombie bucket.  

Somewhat related to that, if you had a bucket policy managed by iamy on a bucket you delete, it would attempt to apply that bucket policy to the non-existent bucket, not exiting this time but generating `aws iam put-bucket-policy` commands that would fail.

This PR addresses both of those issues.

I'm not the worlds greatest go programmer and I ran into a problem attempting to call functions across files,  this is the only way I could get it to work (I would have preferred to call BucketExists directly in the awsdiff loop, rather than instantiating a s3 client object, but no idea how you do that).

I'd suggest this needs some work, which I'm happy to do, but I wanted to make sure the direction I'm headed/problems I'm solving are reasonable first.

