### PR TITLE
Find account via STS GetCallerIdentity

### DIFF
--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -18,6 +18,8 @@ type AwsFetcher struct {
 	// when pushing to AWS
 	SkipFetchingPolicyAndRoleDescriptions bool
 
+	Debug *log.Logger
+
 	iam     *iamClient
 	s3      *s3Client
 	account *Account
@@ -353,7 +355,7 @@ func (a *AwsFetcher) getAccount() (*Account, error) {
 	var err error
 	acct := Account{}
 
-	acct.Id, err = GetAwsAccountId(awsSession())
+	acct.Id, err = GetAwsAccountId(awsSession(), a.Debug)
 	if err == aws.ErrMissingRegion {
 		return nil, errors.New("Error determining the AWS account id - check the AWS_REGION environment variable is set")
 	}

--- a/iamy/awsaccountid.go
+++ b/iamy/awsaccountid.go
@@ -2,6 +2,7 @@ package iamy
 
 import (
 	"errors"
+	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,19 +13,25 @@ import (
 
 // GetAwsAccountId determines the AWS account id associated
 // with the given session
-func GetAwsAccountId(sess *session.Session) (string, error) {
+func GetAwsAccountId(sess *session.Session, debug *log.Logger) (string, error) {
+	debug.Println("Finding AWS account ID via GetUser")
 	accountid, err := determineAccountIdViaGetUser(sess)
 	if err == nil {
+		debug.Println("AWS account ID:", accountid)
 		return accountid, nil
 	}
 
+	debug.Println("Finding AWS account ID via ListUsers")
 	accountid, err = determineAccountIdViaListUsers(sess)
 	if err == nil {
+		debug.Println("AWS account ID:", accountid)
 		return accountid, nil
 	}
 
+	debug.Println("Finding AWS account ID via DefaultSecurityGroup")
 	accountid, err = determineAccountIdViaDefaultSecurityGroup(sess)
 	if err == nil {
+		debug.Println("AWS account ID:", accountid)
 		return accountid, nil
 	}
 

--- a/iamy/awsaccountid.go
+++ b/iamy/awsaccountid.go
@@ -9,13 +9,21 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 // GetAwsAccountId determines the AWS account id associated
 // with the given session
 func GetAwsAccountId(sess *session.Session, debug *log.Logger) (string, error) {
+	debug.Println("Finding AWS account ID via GetCallerIdentity")
+	accountid, err := determineAccountIdViaGetCallerIdentity(sess)
+	if err == nil {
+		debug.Println("AWS account ID:", accountid)
+		return accountid, nil
+	}
+
 	debug.Println("Finding AWS account ID via GetUser")
-	accountid, err := determineAccountIdViaGetUser(sess)
+	accountid, err = determineAccountIdViaGetUser(sess)
 	if err == nil {
 		debug.Println("AWS account ID:", accountid)
 		return accountid, nil
@@ -41,6 +49,15 @@ func GetAwsAccountId(sess *session.Session, debug *log.Logger) (string, error) {
 func getAccountIdFromArn(arn string) string {
 	s := strings.Split(arn, ":")
 	return s[4]
+}
+
+// https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html
+func determineAccountIdViaGetCallerIdentity(sess *session.Session) (string, error) {
+	resp, err := sts.New(sess).GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", err
+	}
+	return *resp.Account, nil
 }
 
 // see http://stackoverflow.com/a/18124234

--- a/pull.go
+++ b/pull.go
@@ -12,7 +12,7 @@ type PullCommandInput struct {
 }
 
 func PullCommand(ui Ui, input PullCommandInput) {
-	aws := iamy.AwsFetcher{}
+	aws := iamy.AwsFetcher{Debug: ui.Debug}
 	data, err := aws.Fetch()
 	if err != nil {
 		ui.Error.Fatal(fmt.Printf("%s", err))

--- a/push.go
+++ b/push.go
@@ -21,6 +21,7 @@ func PushCommand(ui Ui, input PushCommandInput) {
 	}
 	aws := iamy.AwsFetcher{
 		SkipFetchingPolicyAndRoleDescriptions: true,
+		Debug: ui.Debug,
 	}
 
 	allDataFromYaml, err := yaml.Load()


### PR DESCRIPTION
## Problem

After some AWS account spring cleaning, IAMy stopped working:

```
$ iamy pull --delete
Error in init: Can't determine the AWS account id49 <nil>
```

[`GetAwsAccountId`](https://github.com/99designs/iamy/blob/0d1517884364118093c23e8ecb37b4b4900a38d0/iamy/awsaccountid.go#L13-L32) tries three strategies to discover the account ID:

1. IAM GetUser
2. IAM ListUsers
3. EC2 GetDefaultSecurityGroup

An AWS account following best-practices is unlikely to have any of things:

```
$ aws iam get-user
An error occurred (ValidationError) when calling the GetUser operation: Must specify userName when calling with non-User credentials

$ aws iam list-users --query Users
[]

$ aws ec2 describe-security-groups --group-names default
An error occurred (VPCIdNotSpecified) when calling the DescribeSecurityGroups operation: No default VPC for this user
```

## Solution

This PR does two things:

* Adds debug logging to the account ID discovery process.
* Adds a new preferred strategy to use [STS GetCallerIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html) to find the AWS account ID.

### Before

```
$ iamy --debug pull --dry-run
DEBUG 2018/08/21 10:55:56 Finding AWS account ID via GetUser
DEBUG 2018/08/21 10:55:57 Finding AWS account ID via ListUsers
DEBUG 2018/08/21 10:55:58 Finding AWS account ID via DefaultSecurityGroup
Error in init: Can't determine the AWS account id49 <nil>
```

### After

```
$ iamy --debug pull --dry-run
DEBUG 2018/08/21 10:56:37 Finding AWS account ID via GetCallerIdentity
DEBUG 2018/08/21 10:56:39 AWS account ID: 1234123412341234
DEBUG 2018/08/21 10:56:41 Fetching IAM data
…
```