### PR TITLE
Add support for skipping AWS service roles

### DIFF
--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -376,14 +377,20 @@ func (a *AwsFetcher) getAccount() (*Account, error) {
 	return &acct, nil
 }
 
-// isSkippableResource takes the resource name as a string and checks it
-// against known resources that we shouldn't need to manage as it will
-// already be managed by another process (such as Cloudformation roles).
+// isSkippableResource takes the resource identifier as a string and
+// checks it against known resources that we shouldn't need to manage as
+// it will already be managed by another process (such as Cloudformation
+// roles).
+//
 // Returns a boolean of whether it can be skipped and a string of the
 // reasoning why it was skipped.
-func isSkippableManagedResource(resourceName string) (bool, string) {
-	if cfnResourceRegexp.MatchString(resourceName) {
-		return true, fmt.Sprintf("CloudFormation generated resource %s", resourceName)
+func isSkippableManagedResource(resourceIdentifier string) (bool, string) {
+	if cfnResourceRegexp.MatchString(resourceIdentifier) {
+		return true, fmt.Sprintf("CloudFormation generated resource %s", resourceIdentifier)
+	}
+
+	if strings.Contains(resourceIdentifier, "AWSServiceRole") || strings.Contains(resourceIdentifier, "aws-service-role") {
+		return true, fmt.Sprintf("AWS Service role generated resource %s", resourceIdentifier)
 	}
 
 	return false, ""

--- a/iamy/aws_test.go
+++ b/iamy/aws_test.go
@@ -1,0 +1,47 @@
+package iamy
+
+import (
+	"testing"
+)
+
+func TestIsSkippableManagedResource(t *testing.T) {
+	skippables := []string{
+		"myalias-123/iam/role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot.yaml",
+		"AWSServiceRoleTest",
+		"my-example-role-ABCDEFGH1234567",
+	}
+
+	nonSkippables := []string{
+		"myalias-123/iam/user/foo/billy.blogs.yaml",
+		"myalias-123/s3/my-bucket.yaml",
+		"myalias-123/iam/instance-profile/example.yaml",
+	}
+
+	for _, name := range skippables {
+		t.Run(name, func(t *testing.T) {
+
+			skipped, err := isSkippableManagedResource(name)
+			if skipped == false {
+				t.Errorf("expected %s to be skipped but got false", name)
+			}
+
+			if err == "" {
+				t.Errorf("expected %s to output an error message but it was empty", name)
+			}
+		})
+	}
+
+	for _, name := range nonSkippables {
+		t.Run(name, func(t *testing.T) {
+
+			skipped, err := isSkippableManagedResource(name)
+			if skipped == true {
+				t.Errorf("expected %s to not be skipped but got true", name)
+			}
+
+			if err != "" {
+				t.Errorf("expected %s to not output an error message but got: %s", name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
AWS service roles aren't something that end users need to concern
themselves with as they are managed by AWS and automatically applied to
some services that require the interaction.

To support this addition, I've refactored the skipping sections of the
existing functions to use a new method - `isSkippableManagedResource`.
This function consolidates the logic as to whether or not the resource
should be skipped.

Fixes #38