### PR TITLE
Dont decode S3 Bucket policies

### DIFF
--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -120,8 +120,11 @@ func (a *AwsFetcher) fetchIamData() error {
 			}),
 		},
 		func(resp *iam.GetAccountAuthorizationDetailsOutput, lastPage bool) bool {
+			// There's a bug here. This doesn't set the variable outside this function scope
+			// So IAMY just swallows any errors returned from populateIamData()
 			populateIamDataErr = a.populateIamData(resp)
 			if populateIamDataErr != nil {
+				log.Println("Error Fetching IAM Data")
 				return false
 			}
 			return true

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -92,7 +92,7 @@ func (a *AwsFetcher) fetchS3Data() error {
 			continue
 		}
 
-		policyDoc, err := NewPolicyDocumentFromEncodedJson(b.policyJson)
+		policyDoc, err := NewPolicyDocumentFromJson(b.policyJson)
 		if err != nil {
 			return errors.Wrap(err, "Error creating Policy document")
 		}

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -120,11 +120,8 @@ func (a *AwsFetcher) fetchIamData() error {
 			}),
 		},
 		func(resp *iam.GetAccountAuthorizationDetailsOutput, lastPage bool) bool {
-			// There's a bug here. This doesn't set the variable outside this function scope
-			// So IAMY just swallows any errors returned from populateIamData()
 			populateIamDataErr = a.populateIamData(resp)
 			if populateIamDataErr != nil {
-				log.Println("Error Fetching IAM Data")
 				return false
 			}
 			return true

--- a/iamy/policy.go
+++ b/iamy/policy.go
@@ -3,19 +3,13 @@ package iamy
 import (
 	"encoding/json"
 	"log"
-	"net/url"
 	"reflect"
 	"sort"
 )
 
-func NewPolicyDocumentFromEncodedJson(encoded string) (*PolicyDocument, error) {
-	jsonString, err := url.QueryUnescape(encoded)
-	if err != nil {
-		return nil, err
-	}
-
+func NewPolicyDocumentFromEncodedJson(jsonString string) (*PolicyDocument, error) {
 	var doc PolicyDocument
-	if err = json.Unmarshal([]byte(jsonString), &doc); err != nil {
+	if err := json.Unmarshal([]byte(jsonString), &doc); err != nil {
 		return nil, err
 	}
 

--- a/iamy/policy.go
+++ b/iamy/policy.go
@@ -3,15 +3,33 @@ package iamy
 import (
 	"encoding/json"
 	"log"
+	"net/url"
 	"reflect"
 	"sort"
 )
 
-func NewPolicyDocumentFromEncodedJson(jsonString string) (*PolicyDocument, error) {
+func NewPolicyDocumentFromJson(jsonString string) (*PolicyDocument, error) {
 	var doc PolicyDocument
 	if err := json.Unmarshal([]byte(jsonString), &doc); err != nil {
+		log.Printf("Error unmarshalling JSON %s %s", err, jsonString)
 		return nil, err
 	}
+	//log.Printf("Doc %s\nJSON: %s", doc, jsonString)
+
+	return &doc, nil
+}
+
+func NewPolicyDocumentFromEncodedJson(encoded string) (*PolicyDocument, error) {
+	jsonString, err := url.QueryUnescape(encoded)
+	if err != nil {
+		return nil, err
+	}
+	var doc PolicyDocument
+	if err := json.Unmarshal([]byte(jsonString), &doc); err != nil {
+		log.Printf("Error unmarshalling JSON %s %s", err, jsonString)
+		return nil, err
+	}
+	//log.Printf("Doc %s\nJSON: %s", doc, jsonString)
 
 	return &doc, nil
 }

--- a/iamy/policy.go
+++ b/iamy/policy.go
@@ -14,7 +14,6 @@ func NewPolicyDocumentFromJson(jsonString string) (*PolicyDocument, error) {
 		log.Printf("Error unmarshalling JSON %s %s", err, jsonString)
 		return nil, err
 	}
-	//log.Printf("Doc %s\nJSON: %s", doc, jsonString)
 
 	return &doc, nil
 }
@@ -24,14 +23,8 @@ func NewPolicyDocumentFromEncodedJson(encoded string) (*PolicyDocument, error) {
 	if err != nil {
 		return nil, err
 	}
-	var doc PolicyDocument
-	if err := json.Unmarshal([]byte(jsonString), &doc); err != nil {
-		log.Printf("Error unmarshalling JSON %s %s", err, jsonString)
-		return nil, err
-	}
-	//log.Printf("Doc %s\nJSON: %s", doc, jsonString)
 
-	return &doc, nil
+	return NewPolicyDocumentFromJson(jsonString)
 }
 
 // PolicyDocument represents an AWS policy document.

--- a/iamy/policy_test.go
+++ b/iamy/policy_test.go
@@ -126,3 +126,10 @@ Actual:  %#v`, nt.description, nt.input, nt.expected, result)
 		}
 	}
 }
+
+func TestNewPolicyDocumentFromEncodedJson(t *testing.T) {
+	_, err := NewPolicyDocumentFromEncodedJson("{\"Version\":\"2012-10-17\",\"Id\":\"AllowPublicRead\",\"Statement\":[{\"Sid\":\"PublicReadBucketObjects\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::example.com/*\",\"Condition\":{\"StringEquals\":{\"aws:Referer\":\"%zz\"}}}]}")
+	if err != nil {
+		t.Errorf("Error decoding policy %s", err)
+	}
+}

--- a/iamy/policy_test.go
+++ b/iamy/policy_test.go
@@ -127,8 +127,8 @@ Actual:  %#v`, nt.description, nt.input, nt.expected, result)
 	}
 }
 
-func TestNewPolicyDocumentFromEncodedJson(t *testing.T) {
-	_, err := NewPolicyDocumentFromEncodedJson("{\"Version\":\"2012-10-17\",\"Id\":\"AllowPublicRead\",\"Statement\":[{\"Sid\":\"PublicReadBucketObjects\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::example.com/*\",\"Condition\":{\"StringEquals\":{\"aws:Referer\":\"%zz\"}}}]}")
+func TestNewPolicyDocumentFromJson(t *testing.T) {
+	_, err := NewPolicyDocumentFromJson("{\"Version\":\"2012-10-17\",\"Id\":\"AllowPublicRead\",\"Statement\":[{\"Sid\":\"PublicReadBucketObjects\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::example.com/*\",\"Condition\":{\"StringEquals\":{\"aws:Referer\":\"%zz\"}}}]}")
 	if err != nil {
 		t.Errorf("Error decoding policy %s", err)
 	}

--- a/iamy/policy_test.go
+++ b/iamy/policy_test.go
@@ -128,7 +128,7 @@ Actual:  %#v`, nt.description, nt.input, nt.expected, result)
 }
 
 func TestNewPolicyDocumentFromJson(t *testing.T) {
-	_, err := NewPolicyDocumentFromJson("{\"Version\":\"2012-10-17\",\"Id\":\"AllowPublicRead\",\"Statement\":[{\"Sid\":\"PublicReadBucketObjects\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::example.com/*\",\"Condition\":{\"StringEquals\":{\"aws:Referer\":\"%zz\"}}}]}")
+	_, err := NewPolicyDocumentFromJson(`{"Version":"2012-10-17","Id":"AllowPublicRead","Statement":[{"Sid":"PublicReadBucketObjects","Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::example.com/*","Condition":{"StringEquals":{"aws:Referer":"%zz"}}}]}`)
 	if err != nil {
 		t.Errorf("Error decoding policy %s", err)
 	}


### PR DESCRIPTION
This fixes an issue that was introduced in #13. ~I can't really figure out why we would want to decode the Policy, it should never be encoded in the first place as far as I can tell.~
S3 bucket policies are not URL encoded, while other policies are.
If the bucket policy contains invalid encoding, such as `%` followed by non-hexadecimal characters, it creates an error such as:
```
Error decoding policy invalid URL escape "%zz"
```