### PR TITLE
WIP: Dont swallow errors from populateiamdata

### DIFF
--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -22,7 +22,7 @@ type AwsFetcher struct {
 
 	Debug *log.Logger
 
-	iam     *iamClient
+	iam     iamClientiface
 	s3      *s3Client
 	account *Account
 	data    AccountData

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -120,8 +120,11 @@ func (a *AwsFetcher) fetchIamData() error {
 			}),
 		},
 		func(resp *iam.GetAccountAuthorizationDetailsOutput, lastPage bool) bool {
+			// There's a bug here. This doesn't set the variable outside this function scope
+			// So IAMY just swallows any errors returned from populateIamData()
 			populateIamDataErr = a.populateIamData(resp)
 			if populateIamDataErr != nil {
+				log.Println("Error Fetching IAM Data", populateIamDataErr)
 				return false
 			}
 			return true

--- a/iamy/aws_test.go
+++ b/iamy/aws_test.go
@@ -2,6 +2,10 @@ package iamy
 
 import (
 	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
 )
 
 func TestIsSkippableManagedResource(t *testing.T) {
@@ -43,5 +47,58 @@ func TestIsSkippableManagedResource(t *testing.T) {
 				t.Errorf("expected %s to not output an error message but got: %s", name, err)
 			}
 		})
+	}
+}
+
+type mockIam struct {
+	iamClientiface
+	policyDocument string
+}
+
+func (m *mockIam) GetAccountAuthorizationDetailsPages(input *iam.GetAccountAuthorizationDetailsInput, fn func(*iam.GetAccountAuthorizationDetailsOutput, bool) bool) error {
+	now := time.Now()
+	fn(&iam.GetAccountAuthorizationDetailsOutput{
+		Policies: []*iam.ManagedPolicyDetail{
+			{
+				Arn:                           aws.String("arn:aws:iam::aws:policy/IAMReadOnlyAccess"),
+				AttachmentCount:               aws.Int64(0),
+				CreateDate:                    &now,
+				DefaultVersionId:              aws.String("v4"),
+				Description:                   aws.String("Provides read only access to IAM via the AWS Management Console."),
+				IsAttachable:                  aws.Bool(true),
+				Path:                          aws.String("/"),
+				PermissionsBoundaryUsageCount: aws.Int64(0),
+				PolicyId:                      aws.String("ANPAJKSO7NDY4T57MWDSQ"),
+				PolicyName:                    aws.String("IAMReadOnlyAccess"),
+				PolicyVersionList: []*iam.PolicyVersion{
+					{
+						CreateDate:       &now,
+						Document:         &m.policyDocument,
+						IsDefaultVersion: aws.Bool(true),
+						VersionId:        aws.String("v4"),
+					},
+				},
+				UpdateDate: &now,
+			},
+		},
+	}, true)
+	return nil
+}
+
+func (m *mockIam) ListInstanceProfilesPages(*iam.ListInstanceProfilesInput, func(*iam.ListInstanceProfilesOutput, bool) bool) error {
+	return nil
+}
+func TestFetchIamData(t *testing.T) {
+	mockIamClient := &mockIam{
+		policyDocument: "InvalidPolicy%zz}}",
+	}
+
+	fetcher := AwsFetcher{
+		SkipFetchingPolicyAndRoleDescriptions: true,
+		iam:                                   mockIamClient,
+	}
+	err := fetcher.fetchIamData()
+	if err == nil {
+		t.Error("We expected fetch IAM to fail because the policy document was invalid. But it didn't")
 	}
 }

--- a/iamy/iam.go
+++ b/iamy/iam.go
@@ -7,6 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 )
 
+type iamClientiface interface {
+	iamiface.IAMAPI
+	getPolicyDescription(string) (string, error)
+	getRoleDescription(string) (string, error)
+	MustGetSecurityCredsForUser(string) ([]string, []string, bool)
+}
+
 type iamClient struct {
 	iamiface.IAMAPI
 }


### PR DESCRIPTION
This PR creates a failing test to exhibit behaviour found in #57.
When an invalid policy document is returned (either because its' incorrect from AWS or we've not decoded it correctly) that error is swallowed and not shown to the user. Instead the policy and any other policies are not synced from AWS and we get a diff that tries to push them all back up.