### PR TITLE
Add support for basic version requirements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/aws/aws-sdk-go v1.16.23
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/aws/aws-sdk-go v0.0.0-20190104231327-923b7b1b0525 h1:qc2jx43HwaJSlY5U
 github.com/aws/aws-sdk-go v0.0.0-20190104231327-923b7b1b0525/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.16.23 h1:MwBOBeez0XEFVh6DCc888X+nHVBCjUDLnnWXSGGWUgM=
 github.com/aws/aws-sdk-go v1.16.23/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/iamy.go
+++ b/iamy.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/blang/semver"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -96,7 +97,7 @@ func init() {
 }
 
 func performVersionChecks() {
-	currentIAMyVersion, _ := semver.Make(Version)
+	currentIAMyVersion, _ := semver.Make(strings.TrimPrefix(Version, "v"))
 	log.Printf("current version is %s", currentIAMyVersion)
 
 	fileBytes, err := ioutil.ReadFile(versionFileName)


### PR DESCRIPTION
With any project, eventually you get to a stage where you have
configuration defined that works on a specific version of your software.
Upgrading between versions usually requires some effort but it's rolled
out when it's needed. This becomes even more difficult working in a team
where people can have different versions of the software that you use
based on how often they like to update their systems.

To handle these scenarios, you introduce some sort of versioning that
defines what versions you want the configuration to operate with and the
users then need to meet those requirements.

This introduces a basic concept of the versioning for IAMy. The logic is
pretty straight forward.

- If you find a `.iamy-version` file, use the version defined in it. If
  not, continue on.
- If the `.iamy-version` file contains a version number, compare it to
  the local version and ensure that the version in use meets the minimum
  requirements to operate. If it doesn't, inform the user of the
  discrepancy and what is required.

#62 proposes quite a few more coditions to restrain the version however
I don't think that's required for majority of use cases. I think
defining a minimum version covers most of the sharp edges we've
encountered. But, we can always make this more perscriptive if needed.

Closes #62