### PR TITLE
Skip resources tagged with aws:cloudformation:stack-name

### DIFF
--- a/iamy.go
+++ b/iamy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -28,6 +29,10 @@ type Ui struct {
 	Exit         func(code int)
 }
 
+// CFN automatically tags resources with this and other tags:
+// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
+const cloudformationStackNameTag = "aws:cloudformation:stack-name"
+
 func main() {
 	var (
 		debug         = kingpin.Flag("debug", "Show debugging output").Bool()
@@ -35,7 +40,8 @@ func main() {
 		pullDir       = pull.Flag("dir", "The directory to dump yaml files to").Default(defaultDir).Short('d').String()
 		canDelete     = pull.Flag("delete", "Delete extraneous files from destination dir").Bool()
 		lookupCfn     = pull.Flag("accurate-cfn", "Fetch all known resource names from cloudformation to get exact filtering").Bool()
-		skipCfnTagged = pull.Flag("skip-cfn-tagged", "Skips entities or associated entities (buckets for bucket policies) tagged with default cloudformation tags").Bool()
+		skipCfnTagged = pull.Flag("skip-cfn-tagged", fmt.Sprintf("Shorthand for --skip-tagged %s", cloudformationStackNameTag)).Bool()
+		skipTagged    = pull.Flag("skip-tagged", "Skips entities or associated entities (buckets for bucket policies) tagged with a given tag").Strings()
 		push          = kingpin.Command("push", "Syncs IAM users, groups and policies from files to the active AWS account")
 		pushDir       = push.Flag("dir", "The directory to load yaml files from").Default(defaultDir).Short('d').ExistingDir()
 	)
@@ -62,6 +68,10 @@ func main() {
 		log.SetOutput(ioutil.Discard)
 	}
 
+	if *skipCfnTagged {
+		*skipTagged = append(*skipTagged, cloudformationStackNameTag)
+	}
+
 	switch cmd {
 	case push.FullCommand():
 		PushCommand(ui, PushCommandInput{
@@ -73,7 +83,7 @@ func main() {
 			Dir:                  *pullDir,
 			CanDelete:            *canDelete,
 			HeuristicCfnMatching: !*lookupCfn,
-			SkipCfnTagged:        *skipCfnTagged,
+			SkipTagged:           *skipTagged,
 		})
 	}
 }

--- a/iamy.go
+++ b/iamy.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -35,15 +34,14 @@ const cloudformationStackNameTag = "aws:cloudformation:stack-name"
 
 func main() {
 	var (
-		debug         = kingpin.Flag("debug", "Show debugging output").Bool()
-		pull          = kingpin.Command("pull", "Syncs IAM users, groups and policies from the active AWS account to files")
-		pullDir       = pull.Flag("dir", "The directory to dump yaml files to").Default(defaultDir).Short('d').String()
-		canDelete     = pull.Flag("delete", "Delete extraneous files from destination dir").Bool()
-		lookupCfn     = pull.Flag("accurate-cfn", "Fetch all known resource names from cloudformation to get exact filtering").Bool()
-		skipCfnTagged = pull.Flag("skip-cfn-tagged", fmt.Sprintf("Shorthand for --skip-tagged %s", cloudformationStackNameTag)).Bool()
-		skipTagged    = pull.Flag("skip-tagged", "Skips IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
-		push          = kingpin.Command("push", "Syncs IAM users, groups and policies from files to the active AWS account")
-		pushDir       = push.Flag("dir", "The directory to load yaml files from").Default(defaultDir).Short('d').ExistingDir()
+		debug      = kingpin.Flag("debug", "Show debugging output").Bool()
+		pull       = kingpin.Command("pull", "Syncs IAM users, groups and policies from the active AWS account to files")
+		pullDir    = pull.Flag("dir", "The directory to dump yaml files to").Default(defaultDir).Short('d').String()
+		canDelete  = pull.Flag("delete", "Delete extraneous files from destination dir").Bool()
+		lookupCfn  = pull.Flag("accurate-cfn", "Fetch all known resource names from cloudformation to get exact filtering").Bool()
+		skipTagged = pull.Flag("skip-tagged", "Skips IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
+		push       = kingpin.Command("push", "Syncs IAM users, groups and policies from files to the active AWS account")
+		pushDir    = push.Flag("dir", "The directory to load yaml files from").Default(defaultDir).Short('d').ExistingDir()
 	)
 	dryRun = kingpin.Flag("dry-run", "Show what would happen, but don't prompt to do it").Bool()
 
@@ -66,10 +64,6 @@ func main() {
 		log.SetOutput(&logWriter{ui.Debug})
 	} else {
 		log.SetOutput(ioutil.Discard)
-	}
-
-	if *skipCfnTagged {
-		*skipTagged = append(*skipTagged, cloudformationStackNameTag)
 	}
 
 	switch cmd {

--- a/iamy.go
+++ b/iamy.go
@@ -41,7 +41,7 @@ func main() {
 		canDelete     = pull.Flag("delete", "Delete extraneous files from destination dir").Bool()
 		lookupCfn     = pull.Flag("accurate-cfn", "Fetch all known resource names from cloudformation to get exact filtering").Bool()
 		skipCfnTagged = pull.Flag("skip-cfn-tagged", fmt.Sprintf("Shorthand for --skip-tagged %s", cloudformationStackNameTag)).Bool()
-		skipTagged    = pull.Flag("skip-tagged", "Skips entities or associated entities (buckets for bucket policies) tagged with a given tag").Strings()
+		skipTagged    = pull.Flag("skip-tagged", "Skips IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
 		push          = kingpin.Command("push", "Syncs IAM users, groups and policies from files to the active AWS account")
 		pushDir       = push.Flag("dir", "The directory to load yaml files from").Default(defaultDir).Short('d').ExistingDir()
 	)

--- a/iamy.go
+++ b/iamy.go
@@ -30,13 +30,14 @@ type Ui struct {
 
 func main() {
 	var (
-		debug     = kingpin.Flag("debug", "Show debugging output").Bool()
-		pull      = kingpin.Command("pull", "Syncs IAM users, groups and policies from the active AWS account to files")
-		pullDir   = pull.Flag("dir", "The directory to dump yaml files to").Default(defaultDir).Short('d').String()
-		canDelete = pull.Flag("delete", "Delete extraneous files from destination dir").Bool()
-		lookupCfn = pull.Flag("accurate-cfn", "Fetch all known resource names from cloudformation to get exact filtering").Bool()
-		push      = kingpin.Command("push", "Syncs IAM users, groups and policies from files to the active AWS account")
-		pushDir   = push.Flag("dir", "The directory to load yaml files from").Default(defaultDir).Short('d').ExistingDir()
+		debug         = kingpin.Flag("debug", "Show debugging output").Bool()
+		pull          = kingpin.Command("pull", "Syncs IAM users, groups and policies from the active AWS account to files")
+		pullDir       = pull.Flag("dir", "The directory to dump yaml files to").Default(defaultDir).Short('d').String()
+		canDelete     = pull.Flag("delete", "Delete extraneous files from destination dir").Bool()
+		lookupCfn     = pull.Flag("accurate-cfn", "Fetch all known resource names from cloudformation to get exact filtering").Bool()
+		skipCfnTagged = pull.Flag("skip-cfn-tagged", "Skips entities or associated entities (buckets for bucket policies) tagged with default cloudformation tags").Bool()
+		push          = kingpin.Command("push", "Syncs IAM users, groups and policies from files to the active AWS account")
+		pushDir       = push.Flag("dir", "The directory to load yaml files from").Default(defaultDir).Short('d').ExistingDir()
 	)
 	dryRun = kingpin.Flag("dry-run", "Show what would happen, but don't prompt to do it").Bool()
 
@@ -72,6 +73,7 @@ func main() {
 			Dir:                  *pullDir,
 			CanDelete:            *canDelete,
 			HeuristicCfnMatching: !*lookupCfn,
+			SkipCfnTagged:        *skipCfnTagged,
 		})
 	}
 }

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -17,6 +17,7 @@ type AwsFetcher struct {
 	// when pushing to AWS
 	SkipFetchingPolicyAndRoleDescriptions bool
 	HeuristicCfnMatching                  bool
+	SkipCfnTagged                         bool
 
 	Debug *log.Logger
 
@@ -416,8 +417,10 @@ const cloudformationStackNameTag = "aws:cloudformation:stack-name"
 // reasoning why it was skipped.
 
 func (a *AwsFetcher) isSkippableManagedResource(cfnType CfnResourceType, resourceIdentifier string, tags map[string]string) (bool, string) {
-	if stackName, ok := tags[cloudformationStackNameTag]; ok {
-		return true, fmt.Sprintf("CloudFormation generated resource %s in stack %s", resourceIdentifier, stackName)
+	if a.SkipCfnTagged {
+		if stackName, ok := tags[cloudformationStackNameTag]; ok {
+			return true, fmt.Sprintf("CloudFormation generated resource %s in stack %s", resourceIdentifier, stackName)
+		}
 	}
 
 	if a.cfn.IsManagedResource(cfnType, resourceIdentifier) {

--- a/iamy/aws_test.go
+++ b/iamy/aws_test.go
@@ -22,7 +22,7 @@ func TestIsSkippableManagedResource(t *testing.T) {
 	for _, name := range skippables {
 		t.Run(name, func(t *testing.T) {
 
-			skipped, err := f.isSkippableManagedResource(CfnIamRole, name)
+			skipped, err := f.isSkippableManagedResource(CfnIamRole, name, map[string]string{})
 			if skipped == false {
 				t.Errorf("expected %s to be skipped but got false", name)
 			}
@@ -36,7 +36,7 @@ func TestIsSkippableManagedResource(t *testing.T) {
 	for _, name := range nonSkippables {
 		t.Run(name, func(t *testing.T) {
 
-			skipped, err := f.isSkippableManagedResource(CfnIamRole, name)
+			skipped, err := f.isSkippableManagedResource(CfnIamRole, name, map[string]string{})
 			if skipped == true {
 				t.Errorf("expected %s to not be skipped but got true", name)
 			}
@@ -45,5 +45,31 @@ func TestIsSkippableManagedResource(t *testing.T) {
 				t.Errorf("expected %s to not output an error message but got: %s", name, err)
 			}
 		})
+	}
+}
+
+func TestSkippableTaggedResources(t *testing.T) {
+	f := AwsFetcher{cfn: &cfnClient{}}
+	skippableTags := map[string]string{"aws:cloudformation:stack-name": "my-stack"}
+
+	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", skippableTags)
+	if err == "" {
+		t.Errorf("expected an error message but it was empty")
+	}
+	if skipped == false {
+		t.Errorf("expected resource to be skipped but got false")
+	}
+}
+
+func TestNonSkippableTaggedResources(t *testing.T) {
+	f := AwsFetcher{cfn: &cfnClient{}}
+	nonSkippableTags := map[string]string{"Name": "blah"}
+
+	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", nonSkippableTags)
+	if err != "" {
+		t.Errorf("expected no error message but got: %s", err)
+	}
+	if skipped == true {
+		t.Errorf("expected resource to not be skipped but got true")
 	}
 }

--- a/iamy/aws_test.go
+++ b/iamy/aws_test.go
@@ -54,7 +54,7 @@ func TestIsSkippableManagedResource(t *testing.T) {
 
 func TestSkippableS3TaggedResources(t *testing.T) {
 	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}}
-	skippableTags := map[string]string{"aws:cloudformation:stack-name": "my-stack"}
+	skippableTags := map[string]string{cloudformationStackNameTag: "my-stack"}
 
 	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", skippableTags)
 	if err == "" {
@@ -67,7 +67,7 @@ func TestSkippableS3TaggedResources(t *testing.T) {
 
 func TestSkippableS3TaggedResources_WithNoSkipTags(t *testing.T) {
 	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}}
-	skippableTags := map[string]string{"aws:cloudformation:stack-name": "my-stack"}
+	skippableTags := map[string]string{cloudformationStackNameTag: "my-stack"}
 
 	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", skippableTags)
 	if err != "" {
@@ -93,7 +93,7 @@ func TestNonSkippableTaggedResources(t *testing.T) {
 
 func TestSkippableIAMUserResource(t *testing.T) {
 	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}}
-	key := "aws:cloudformation:stack-name"
+	key := cloudformationStackNameTag
 	val := "my-stack"
 	userName := "my-user"
 	path := "/"
@@ -112,7 +112,7 @@ func TestSkippableIAMUserResource(t *testing.T) {
 
 func TestSkippableIAMUserResource_WithNoSkipTags(t *testing.T) {
 	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}}
-	key := "aws:cloudformation:stack-name"
+	key := cloudformationStackNameTag
 	val := "my-stack"
 	userName := "my-user"
 	path := "/"
@@ -136,7 +136,7 @@ func TestSkippableIAMUserResource_WithNoSkipTags(t *testing.T) {
 
 func TestSkippableIAMRoleResource(t *testing.T) {
 	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}}
-	key := "aws:cloudformation:stack-name"
+	key := cloudformationStackNameTag
 	val := "my-stack"
 	roleName := "my-role"
 	path := "/"
@@ -155,7 +155,7 @@ func TestSkippableIAMRoleResource(t *testing.T) {
 
 func TestSkippableIAMRoleResource_WithNoSkipTags(t *testing.T) {
 	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}, SkipFetchingPolicyAndRoleDescriptions: true}
-	key := "aws:cloudformation:stack-name"
+	key := cloudformationStackNameTag
 	val := "my-stack"
 	roleName := "my-role"
 	path := "/"

--- a/iamy/aws_test.go
+++ b/iamy/aws_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
+const cloudformationStackNameTag = "aws:cloudformation:stack-name"
+
 func TestIsSkippableManagedResource(t *testing.T) {
 	skippables := []string{
 		"myalias-123/iam/role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot.yaml",
@@ -51,7 +53,7 @@ func TestIsSkippableManagedResource(t *testing.T) {
 }
 
 func TestSkippableS3TaggedResources(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipCfnTagged: true}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}}
 	skippableTags := map[string]string{"aws:cloudformation:stack-name": "my-stack"}
 
 	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", skippableTags)
@@ -63,8 +65,8 @@ func TestSkippableS3TaggedResources(t *testing.T) {
 	}
 }
 
-func TestSkippableS3TaggedResources_WithSkipFalse(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipCfnTagged: false}
+func TestSkippableS3TaggedResources_WithNoSkipTags(t *testing.T) {
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}}
 	skippableTags := map[string]string{"aws:cloudformation:stack-name": "my-stack"}
 
 	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", skippableTags)
@@ -77,7 +79,7 @@ func TestSkippableS3TaggedResources_WithSkipFalse(t *testing.T) {
 }
 
 func TestNonSkippableTaggedResources(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipCfnTagged: true}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}}
 	nonSkippableTags := map[string]string{"Name": "blah"}
 
 	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", nonSkippableTags)
@@ -90,7 +92,7 @@ func TestNonSkippableTaggedResources(t *testing.T) {
 }
 
 func TestSkippableIAMUserResource(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipCfnTagged: true}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}}
 	key := "aws:cloudformation:stack-name"
 	val := "my-stack"
 	userName := "my-user"
@@ -108,8 +110,8 @@ func TestSkippableIAMUserResource(t *testing.T) {
 	}
 }
 
-func TestSkippableIAMUserResource_WithSkipFalse(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipCfnTagged: false}
+func TestSkippableIAMUserResource_WithNoSkipTags(t *testing.T) {
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}}
 	key := "aws:cloudformation:stack-name"
 	val := "my-stack"
 	userName := "my-user"
@@ -128,12 +130,12 @@ func TestSkippableIAMUserResource_WithSkipFalse(t *testing.T) {
 	}
 
 	if !foundUser {
-		t.Error("Expected to not skip user with CFN tags when SkipCfnTagged: false")
+		t.Error("Expected to not skip user with CFN tags when SkipTagged: []string{}")
 	}
 }
 
 func TestSkippableIAMRoleResource(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipCfnTagged: true}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}}
 	key := "aws:cloudformation:stack-name"
 	val := "my-stack"
 	roleName := "my-role"
@@ -151,8 +153,8 @@ func TestSkippableIAMRoleResource(t *testing.T) {
 	}
 }
 
-func TestSkippableIAMRoleResource_WithSkipFalse(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipCfnTagged: false, SkipFetchingPolicyAndRoleDescriptions: true}
+func TestSkippableIAMRoleResource_WithNoSkipTags(t *testing.T) {
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}, SkipFetchingPolicyAndRoleDescriptions: true}
 	key := "aws:cloudformation:stack-name"
 	val := "my-stack"
 	roleName := "my-role"
@@ -171,6 +173,6 @@ func TestSkippableIAMRoleResource_WithSkipFalse(t *testing.T) {
 		}
 	}
 	if !foundRole {
-		t.Error("Expected to not skip role with CFN tags and SkipCfnTagged: false")
+		t.Error("Expected to not skip role with CFN tags and SkipTagged: []string{}")
 	}
 }

--- a/iamy/iam.go
+++ b/iamy/iam.go
@@ -27,7 +27,7 @@ func (c *iamClient) getPolicyDescription(arn string) (string, error) {
 
 func (c *iamClient) getRoleDescription(name string) (string, error) {
 	resp, err := c.GetRole(&iam.GetRoleInput{RoleName: &name})
-	if err == nil && resp.Role.Description != nil {
+	if err == nil && resp.Role != nil && resp.Role.Description != nil {
 		return *resp.Role.Description, nil
 	}
 	return "", err

--- a/pull.go
+++ b/pull.go
@@ -10,10 +10,11 @@ type PullCommandInput struct {
 	Dir                  string
 	CanDelete            bool
 	HeuristicCfnMatching bool
+	SkipCfnTagged        bool
 }
 
 func PullCommand(ui Ui, input PullCommandInput) {
-	aws := iamy.AwsFetcher{Debug: ui.Debug, HeuristicCfnMatching: input.HeuristicCfnMatching}
+	aws := iamy.AwsFetcher{Debug: ui.Debug, HeuristicCfnMatching: input.HeuristicCfnMatching, SkipCfnTagged: input.SkipCfnTagged}
 	data, err := aws.Fetch()
 	if err != nil {
 		ui.Error.Fatal(fmt.Printf("%s", err))

--- a/pull.go
+++ b/pull.go
@@ -10,11 +10,11 @@ type PullCommandInput struct {
 	Dir                  string
 	CanDelete            bool
 	HeuristicCfnMatching bool
-	SkipCfnTagged        bool
+	SkipTagged           []string
 }
 
 func PullCommand(ui Ui, input PullCommandInput) {
-	aws := iamy.AwsFetcher{Debug: ui.Debug, HeuristicCfnMatching: input.HeuristicCfnMatching, SkipCfnTagged: input.SkipCfnTagged}
+	aws := iamy.AwsFetcher{Debug: ui.Debug, HeuristicCfnMatching: input.HeuristicCfnMatching, SkipTagged: input.SkipTagged}
 	data, err := aws.Fetch()
 	if err != nil {
 		ui.Error.Fatal(fmt.Printf("%s", err))


### PR DESCRIPTION
CloudFormation [automatically tags resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html) with default tags including the stack name, id and logical id. We can infer that the resource is managed by CloudFormation by looking for these tags and ignoring them.

This makes it possible for iamy to ignore bucket policies for buckets created with CFN, which was the main driver for this PR - We had to move bucket policies out of CFN to iamy to avoid both of them trying to manage them.

I've also added this functionality to users & roles since tags are available in the existing api call responses and it makes sense to be consistent. This should make it possible for iamy to ignore CFN created users or roles that specify `RoleName` or `UserName`.

`iamy pull --delete --debug` output:

```
DEBUG 2020/08/02 09:58:53 CloudFormation generated resource my-s3-bucket in stack my-stack
```